### PR TITLE
Add LCDproc as a valid value for screen type in configure.php

### DIFF
--- a/admin/configure.php
+++ b/admin/configure.php
@@ -1437,6 +1437,7 @@ else:
 	    <option <?php if ($configmmdvm['General']['Display'] == "Nextion") {echo 'selected="selected" ';}; ?>value="Nextion">Nextion</option>
 	    <option <?php if ($configmmdvm['General']['Display'] == "HD44780") {echo 'selected="selected" ';}; ?>value="HD44780">HD44780</option>
 	    <option <?php if ($configmmdvm['General']['Display'] == "TFT Serial") {echo 'selected="selected" ';}; ?>value="TFT Serial">TFT Serial</option>
+	    <option <?php if ($configmmdvm['General']['Display'] == "LCDproc") {echo 'selected="selected" ';}; ?>value="LCDproc">LCDproc</option>
 	    </select>
 	    Port: <select name="mmdvmDisplayPort">
 	    <option <?php if (($configmmdvm['General']['Display'] == "None") || ($configmmdvm['General']['Display'] == "") ) {echo 'selected="selected" ';}; ?>value="None">None</option>


### PR DESCRIPTION
Stops the dashboard removing "LCDproc" and defaulting to "None" every time I change another setting!
LCDproc server will default to localhost (127.0.0.1), however this can be changed if needed in admin/expert mmdvmhost editor

-- am i the only one using LCDproc --