### PR TITLE
Fixed tooltips on config title fields and callsign in titles.

### DIFF
--- a/admin/config_backup.php
+++ b/admin/config_backup.php
@@ -26,7 +26,7 @@ if ($_SERVER["PHP_SELF"] == "/admin/config_backup.php") {
     <meta name="KeyWords" content="Pi-Star" />
     <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
     <meta http-equiv="pragma" content="no-cache" />
-<link rel="shortcut icon" href="images/favicon.ico" type="image/x-icon">
+    <link rel="shortcut icon" href="images/favicon.ico" type="image/x-icon">
     <meta http-equiv="Expires" content="0" />
     <title>Pi-Star - <?php echo $lang['digital_voice']." ".$lang['dashboard']." - ".$lang['backup_restore'];?></title>
     <link rel="stylesheet" type="text/css" href="css/ircddb.css?version=1.3" />

--- a/admin/configure.php
+++ b/admin/configure.php
@@ -107,9 +107,9 @@ $MYCALL=strtoupper($callsign);
     <meta name="KeyWords" content="Pi-Star, MW0MWZ" />
     <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
     <meta http-equiv="pragma" content="no-cache" />
-<link rel="shortcut icon" href="images/favicon.ico" type="image/x-icon">
+    <link rel="shortcut icon" href="images/favicon.ico" type="image/x-icon">
     <meta http-equiv="Expires" content="0" />
-    <title><?php echo "$MYCALL"." - ".$lang['digital_voice']." ".$lang['dashboard']." - ".$lang['configuration'];?></title>
+    <title><?php echo $configs["gatewayCallsign"].$lang['digital_voice']." ".$lang['dashboard']." - ".$lang['configuration'];?></title>
     <link rel="stylesheet" type="text/css" href="css/ircddb.css?version=1.3" />
     <script type="text/javascript">
 	function submitform()

--- a/admin/configure.php
+++ b/admin/configure.php
@@ -1082,8 +1082,11 @@ if ($_SERVER["PHP_SELF"] == "/admin/configure.php") {
 	  $currHostname = exec('cat /etc/hostname');
 	  $rollHostname = 'sudo sed -i "s/'.$currHostname.'/'.$newHostnameLower.'/" /etc/hostname';
 	  $rollHosts = 'sudo sed -i "s/'.$currHostname.'/'.$newHostnameLower.'/" /etc/hosts';
+    $rollMotd = 'sudo sed -i "s/'.$currHostname.'/'.$newHostnameLower.'/" /etc/motd';
 	  system($rollHostname);
 	  system($rollHosts);
+	  system($rollMotd);
+
 	  if (file_exists('/etc/hostapd/hostapd.conf')) {
 		  // Update the Hotspot name to the Hostname
 		  $rollApSsid = 'sudo sed -i "/ssid=/c\\ssid='.$newHostnameLower.'" /etc/hostapd/hostapd.conf';

--- a/admin/expert/edit_dmrgateway.php
+++ b/admin/expert/edit_dmrgateway.php
@@ -21,7 +21,7 @@ require_once('../config/version.php');
     <meta name="KeyWords" content="Pi-Star" />
     <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
     <meta http-equiv="pragma" content="no-cache" />
-<link rel="shortcut icon" href="images/favicon.ico" type="image/x-icon">
+    <link rel="shortcut icon" href="images/favicon.ico" type="image/x-icon">
     <meta http-equiv="Expires" content="0" />
     <title>Pi-Star - Digital Voice Dashboard - Expert Editor</title>
     <link rel="stylesheet" type="text/css" href="../css/ircddb.css?version=1.3" />

--- a/admin/expert/edit_dstarrepeater.php
+++ b/admin/expert/edit_dstarrepeater.php
@@ -21,7 +21,7 @@ require_once('../config/version.php');
     <meta name="KeyWords" content="Pi-Star" />
     <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
     <meta http-equiv="pragma" content="no-cache" />
-<link rel="shortcut icon" href="images/favicon.ico" type="image/x-icon">
+    <link rel="shortcut icon" href="images/favicon.ico" type="image/x-icon">
     <meta http-equiv="Expires" content="0" />
     <title>Pi-Star - Digital Voice Dashboard - Expert Editor</title>
     <link rel="stylesheet" type="text/css" href="../css/ircddb.css?version=1.3" />

--- a/admin/expert/edit_ircddbgateway.php
+++ b/admin/expert/edit_ircddbgateway.php
@@ -21,7 +21,7 @@ require_once('../config/version.php');
     <meta name="KeyWords" content="Pi-Star" />
     <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
     <meta http-equiv="pragma" content="no-cache" />
-<link rel="shortcut icon" href="images/favicon.ico" type="image/x-icon">
+    <link rel="shortcut icon" href="images/favicon.ico" type="image/x-icon">
     <meta http-equiv="Expires" content="0" />
     <title>Pi-Star - Digital Voice Dashboard - Expert Editor</title>
     <link rel="stylesheet" type="text/css" href="../css/ircddb.css?version=1.3" />

--- a/admin/expert/edit_mmdvmhost.php
+++ b/admin/expert/edit_mmdvmhost.php
@@ -21,7 +21,7 @@ require_once('../config/version.php');
     <meta name="KeyWords" content="Pi-Star" />
     <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
     <meta http-equiv="pragma" content="no-cache" />
-<link rel="shortcut icon" href="images/favicon.ico" type="image/x-icon">
+    <link rel="shortcut icon" href="images/favicon.ico" type="image/x-icon">
     <meta http-equiv="Expires" content="0" />
     <title>Pi-Star - Digital Voice Dashboard - Expert Editor</title>
     <link rel="stylesheet" type="text/css" href="../css/ircddb.css?version=1.3" />

--- a/admin/expert/edit_p25gateway.php
+++ b/admin/expert/edit_p25gateway.php
@@ -21,7 +21,7 @@ require_once('../config/version.php');
     <meta name="KeyWords" content="Pi-Star" />
     <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
     <meta http-equiv="pragma" content="no-cache" />
-<link rel="shortcut icon" href="images/favicon.ico" type="image/x-icon">
+    <link rel="shortcut icon" href="images/favicon.ico" type="image/x-icon">
     <meta http-equiv="Expires" content="0" />
     <title>Pi-Star - Digital Voice Dashboard - Expert Editor</title>
     <link rel="stylesheet" type="text/css" href="../css/ircddb.css?version=1.3" />

--- a/admin/expert/edit_pistar-remote.php
+++ b/admin/expert/edit_pistar-remote.php
@@ -21,7 +21,7 @@ require_once('../config/version.php');
     <meta name="KeyWords" content="Pi-Star" />
     <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
     <meta http-equiv="pragma" content="no-cache" />
-<link rel="shortcut icon" href="images/favicon.ico" type="image/x-icon">
+    <link rel="shortcut icon" href="images/favicon.ico" type="image/x-icon">
     <meta http-equiv="Expires" content="0" />
     <title>Pi-Star - Digital Voice Dashboard - Expert Editor</title>
     <link rel="stylesheet" type="text/css" href="../css/ircddb.css?version=1.3" />

--- a/admin/expert/edit_starnetserver.php
+++ b/admin/expert/edit_starnetserver.php
@@ -21,7 +21,7 @@ require_once('../config/version.php');
     <meta name="KeyWords" content="Pi-Star" />
     <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
     <meta http-equiv="pragma" content="no-cache" />
-<link rel="shortcut icon" href="images/favicon.ico" type="image/x-icon">
+    <link rel="shortcut icon" href="images/favicon.ico" type="image/x-icon">
     <meta http-equiv="Expires" content="0" />
     <title>Pi-Star - Digital Voice Dashboard - Expert Editor</title>
     <link rel="stylesheet" type="text/css" href="../css/ircddb.css?version=1.3" />

--- a/admin/expert/edit_timeserver.php
+++ b/admin/expert/edit_timeserver.php
@@ -21,7 +21,7 @@ require_once('../config/version.php');
     <meta name="KeyWords" content="Pi-Star" />
     <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
     <meta http-equiv="pragma" content="no-cache" />
-<link rel="shortcut icon" href="images/favicon.ico" type="image/x-icon">
+    <link rel="shortcut icon" href="images/favicon.ico" type="image/x-icon">
     <meta http-equiv="Expires" content="0" />
     <title>Pi-Star - Digital Voice Dashboard - Expert Editor</title>
     <link rel="stylesheet" type="text/css" href="../css/ircddb.css?version=1.3" />

--- a/admin/expert/edit_ysfgateway.php
+++ b/admin/expert/edit_ysfgateway.php
@@ -21,7 +21,7 @@ require_once('../config/version.php');
     <meta name="KeyWords" content="Pi-Star" />
     <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
     <meta http-equiv="pragma" content="no-cache" />
-<link rel="shortcut icon" href="images/favicon.ico" type="image/x-icon">
+    <link rel="shortcut icon" href="images/favicon.ico" type="image/x-icon">
     <meta http-equiv="Expires" content="0" />
     <title>Pi-Star - Digital Voice Dashboard - Expert Editor</title>
     <link rel="stylesheet" type="text/css" href="../css/ircddb.css?version=1.3" />

--- a/admin/expert/index.php
+++ b/admin/expert/index.php
@@ -21,7 +21,7 @@ require_once('../config/version.php');
     <meta name="KeyWords" content="Pi-Star" />
     <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
     <meta http-equiv="pragma" content="no-cache" />
-<link rel="shortcut icon" href="images/favicon.ico" type="image/x-icon">
+    <link rel="shortcut icon" href="images/favicon.ico" type="image/x-icon">
     <meta http-equiv="Expires" content="0" />
     <title>Pi-Star - Digital Voice Dashboard - Expert Editor</title>
     <link rel="stylesheet" type="text/css" href="../css/ircddb.css?version=1.3" />

--- a/admin/expert/ssh_access.php
+++ b/admin/expert/ssh_access.php
@@ -29,7 +29,7 @@ if ($_SERVER["PHP_SELF"] == "/admin/expert/ssh_access.php") {
     <meta name="KeyWords" content="Pi-Star" />
     <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
     <meta http-equiv="pragma" content="no-cache" />
-<link rel="shortcut icon" href="images/favicon.ico" type="image/x-icon">
+    <link rel="shortcut icon" href="images/favicon.ico" type="image/x-icon">
     <meta http-equiv="Expires" content="0" />
     <title>Pi-Star - <?php echo $lang['digital_voice']." ".$lang['dashboard']." - SSH";?></title>
     <link rel="stylesheet" type="text/css" href="../css/ircddb.css?version=1.3" />

--- a/admin/live_modem_log.php
+++ b/admin/live_modem_log.php
@@ -53,7 +53,7 @@ if ($_SERVER["PHP_SELF"] == "/admin/live_modem_log.php") {
     <meta name="KeyWords" content="Pi-Star" />
     <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
     <meta http-equiv="pragma" content="no-cache" />
-<link rel="shortcut icon" href="images/favicon.ico" type="image/x-icon">
+    <link rel="shortcut icon" href="images/favicon.ico" type="image/x-icon">
     <meta http-equiv="Expires" content="0" />
     <title>Pi-Star - <?php echo $lang['digital_voice']." ".$lang['dashboard']." - ".$lang['live_logs'];?></title>
     <link rel="stylesheet" type="text/css" href="css/ircddb.css?version=1.3" />

--- a/admin/power.php
+++ b/admin/power.php
@@ -27,7 +27,7 @@ if ($_SERVER["PHP_SELF"] == "/admin/power.php") {
     <meta name="KeyWords" content="Pi-Star" />
     <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
     <meta http-equiv="pragma" content="no-cache" />
-<link rel="shortcut icon" href="images/favicon.ico" type="image/x-icon">
+    <link rel="shortcut icon" href="images/favicon.ico" type="image/x-icon">
     <meta http-equiv="Expires" content="0" />
     <title>Pi-Star - <?php echo $lang['digital_voice']." ".$lang['dashboard']." - ".$lang['power'];?></title>
     <link rel="stylesheet" type="text/css" href="css/ircddb.css?version=1.3" />

--- a/admin/sysinfo.php
+++ b/admin/sysinfo.php
@@ -87,7 +87,7 @@ function formatSize( $bytes ) {
     <meta name="KeyWords" content="Pi-Star" />
     <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
     <meta http-equiv="pragma" content="no-cache" />
-<link rel="shortcut icon" href="images/favicon.ico" type="image/x-icon">
+    <link rel="shortcut icon" href="images/favicon.ico" type="image/x-icon">
     <meta http-equiv="Expires" content="0" />
     <title>Pi-Star - <?php echo $lang['digital_voice']." ".$lang['dashboard']." - ".$lang['update'];?></title>
     <link rel="stylesheet" type="text/css" href="css/ircddb.css?version=1.3" />

--- a/admin/update.php
+++ b/admin/update.php
@@ -52,7 +52,7 @@ if ($_SERVER["PHP_SELF"] == "/admin/update.php") {
     <meta name="KeyWords" content="Pi-Star" />
     <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
     <meta http-equiv="pragma" content="no-cache" />
-<link rel="shortcut icon" href="images/favicon.ico" type="image/x-icon">
+    <link rel="shortcut icon" href="images/favicon.ico" type="image/x-icon">
     <meta http-equiv="Expires" content="0" />
     <title>Pi-Star - <?php echo $lang['digital_voice']." ".$lang['dashboard']." - ".$lang['update'];?></title>
     <link rel="stylesheet" type="text/css" href="css/ircddb.css?version=1.3" />

--- a/admin/wifi.php
+++ b/admin/wifi.php
@@ -14,7 +14,7 @@ echo '<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
 <meta name="KeyWords" content="Pi-Star, MW0MWZ" />
 <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
 <meta http-equiv="pragma" content="no-cache" />
-<link rel="shortcut icon" href="images/favicon.ico" type="image/x-icon">
+    <link rel="shortcut icon" href="images/favicon.ico" type="image/x-icon">
 <meta http-equiv="Expires" content="0" />
 <link rel="stylesheet" type="text/css" href="css/ircddb.css?version=1.3" />
 <link rel="stylesheet" type="text/css" href="wifi/styles.css" />

--- a/css/ircddb.css
+++ b/css/ircddb.css
@@ -107,7 +107,6 @@ table td {
     font-family: "Lucidia Console",Monaco,monospace;
     text-decoration: none;
     border: 1px solid #000000;
-    overflow-x: hidden;
 }
 
 body {
@@ -117,7 +116,6 @@ body {
 
 a {
     text-decoration:none;
-    
 }
 
 a:link, a:visited {
@@ -157,7 +155,7 @@ a.tooltip:hover span {
     color: #000000;
     border:1px solid #000000;
     background: #f7f7f7;
-    font: 12px Verdana, sans-serif; 
+    font: 12px Verdana, sans-serif;
     text-align: left;
 }
 
@@ -208,7 +206,7 @@ a.tooltip2:hover span {
     color: #000000;
     border:1px solid #000000;
     background: #f7f7f7;
-    font: 12px Verdana, sans-serif; 
+    font: 12px Verdana, sans-serif;
     text-align: left;
 }
 

--- a/index.php
+++ b/index.php
@@ -37,8 +37,8 @@ $configPistarRelease = parse_ini_file($pistarReleaseConfig, true);
     <meta http-equiv="cache-control" content="no-cache, no-store, must-revalidate" />
     <meta http-equiv="expires" content="0" />
     <meta http-equiv="pragma" content="no-cache" />
-<link rel="shortcut icon" href="images/favicon.ico" type="image/x-icon">
-    <title><?php echo "$MYCALL"." - ".$lang['digital_voice']." ".$lang['dashboard'];?></title>
+    <link rel="shortcut icon" href="images/favicon.ico" type="image/x-icon">
+    <title><?php echo $configs["gatewayCallsign"].$lang['digital_voice']." ".$lang['dashboard'];?></title>
 <?php include_once "config/browserdetect.php"; ?>
     <script type="text/javascript" src="/jquery.min.js"></script>
     <script type="text/javascript" src="/functions.js"></script>


### PR DESCRIPTION
- Titles on some pages were M1ABC rather than the proper set callsign.
- Tooltips on the config page in 'td' were being obscured 
- Spacing issues fixed to match rest of styling.