### PR TITLE
Cleanup of /n insertion on ircddbgateway lang

### DIFF
--- a/admin/configure.php
+++ b/admin/configure.php
@@ -1949,6 +1949,7 @@ fclose($dextraFile);
                 $ircLanguageFileLine = fgets($ircLanguageFile);
                 $ircLanguage = preg_split('/;/', $ircLanguageFileLine);
                 if ((strpos($ircLanguage[0], '#') === FALSE ) && ($ircLanguage[0] != '')) {
+			$ircLanguage[2] = rtrim($ircLanguage[2]);
                         if ($testIrcLanguage == $ircLanguage[1]) { echo "      <option value=\"$ircLanguage[1],$ircLanguage[2]\" selected=\"selected\">".htmlspecialchars($ircLanguage[0])."</option>\n"; }
                         else { echo "      <option value=\"$ircLanguage[1],$ircLanguage[2]\">".htmlspecialchars($ircLanguage[0])."</option>\n"; }
                 }


### PR DESCRIPTION
trims the new line insertion pulled from the ircddbgateway_languages.inc before allowing it to be inserted into the HTML form.