### PR TITLE
fix getActualLink for DMR, no priv call and show unlinked

### DIFF
--- a/mmdvmhost/functions.php
+++ b/mmdvmhost/functions.php
@@ -589,6 +589,12 @@ function getActualLink($logLines, $mode) {
 					$to = trim(substr($logLine, strpos($logLine,"to") + 3));
 				}
 				if ($to !== "") {
+					if (substr($to, 0, 3) !== 'TG ') {
+						continue;
+					}
+					if ($to === "TG 4000") {
+						return "not linked";
+					}
 					if (strpos($to, ',') !== false) {
 						$to = substr($to, 0, strpos($to, ','));
 					}
@@ -608,6 +614,12 @@ function getActualLink($logLines, $mode) {
 					$to = trim(substr($logLine, strpos($logLine,"to") + 3));
 				}
 				if ($to !== "") {
+					if (substr($to, 0, 3) !== 'TG ') {
+						continue;
+					}
+					if ($to === "TG 4000") {
+						return "not linked";
+					}
 					if (strpos($to, ',') !== false) {
 						$to = substr($to, 0, strpos($to, ','));
 					}


### PR DESCRIPTION
Don't show private calls (including our own callsign, when last call was an incoming private call...) as active links and show "not linked" after we unlink with TG 4000.