### PR TITLE
YSF Network Status is not correctly displayed on dashbaord due to lea…

### DIFF
--- a/mmdvmhost/functions.php
+++ b/mmdvmhost/functions.php
@@ -145,13 +145,13 @@ function getYSFGatewayLog() {
 	$logLines2 = array();
 	if (file_exists(YSFGATEWAYLOGPATH."/".YSFGATEWAYLOGPREFIX."-".gmdate("Y-m-d").".log")) {
 		$logPath = YSFGATEWAYLOGPATH."/".YSFGATEWAYLOGPREFIX."-".gmdate("Y-m-d").".log";
-		$logLines1 = explode("\n", `egrep -h "repeater|Starting|Disconnect|Connect|Automatic|Disconnecting|Reverting" $logPath | tail -250`);
+		$logLines1 = explode("\n", `egrep -h "repeater|Starting|Disconnect|Connect|Automatic|Disconnecting|Reverting" $logPath | tail -250 | sed \'s/^[A-Z]\:\s//\'`);
 	}
 	$logLines1 = array_slice($logLines1, -250);
 	if (sizeof($logLines1) < 250) {
 		if (file_exists(YSFGATEWAYLOGPATH."/".YSFGATEWAYLOGPREFIX."-".gmdate("Y-m-d", time() - 86340).".log")) {
 			$logPath = YSFGATEWAYLOGPATH."/".YSFGATEWAYLOGPREFIX."-".gmdate("Y-m-d", time() - 86340).".log";
-			$logLines2 = explode("\n", `egrep -h "repeater|Starting|Disconnect|Connect|Automatic|Disconnecting|Reverting" $logPath | tail -250`);
+			$logLines2 = explode("\n", `egrep -h "repeater|Starting|Disconnect|Connect|Automatic|Disconnecting|Reverting" $logPath | tail -250 | sed \'s/^[A-Z]\:\s//\'`);
 		}
 	}
 	$logLines2 = array_slice($logLines2, -250);


### PR DESCRIPTION
Hello Andy,

The current YSF Network Status is not correctly displayed.

The problem is the leading characters in log line. For example:

M: 2018-02-14 04:54:13.823 DMR Header received from 0 to TG 6
M: 2018-02-14 04:54:14.248 DMR received end of voice transmission
M: 2018-02-14 04:59:13.812 DMR Header received from 0 to TG 6
M: 2018-02-14 04:59:14.233 DMR received end of voice transmission

That will cause the reorder problem in later sorting function.

I believe this issue should also apply to P25, but I have no P25 to verify.
I'll leave the P25 to you.

Regards,
Yngwie