### PR TITLE
Correctly display DMR Master in case XLX/BM/DMR+ servers with identical IP

### DIFF
--- a/mmdvmhost/repeaterinfo.php
+++ b/mmdvmhost/repeaterinfo.php
@@ -136,9 +136,9 @@ if ($dmrMasterHost == '127.0.0.1') {
 		$dmrMasterLine = fgets($dmrMasterFile);
                 $dmrMasterHostF = preg_split('/\s+/', $dmrMasterLine);
 		if ((strpos($dmrMasterHostF[0], '#') === FALSE) && ($dmrMasterHostF[0] != '')) {
-			if ($xlxMasterHost1 == $dmrMasterHostF[2]) { $xlxMasterHost1 = str_replace('_', ' ', $dmrMasterHostF[0]); }
-			if ($dmrMasterHost1 == $dmrMasterHostF[2]) { $dmrMasterHost1 = str_replace('_', ' ', $dmrMasterHostF[0]); }
-			if ($dmrMasterHost2 == $dmrMasterHostF[2]) { $dmrMasterHost2 = str_replace('_', ' ', $dmrMasterHostF[0]); }
+			if ((strpos($dmrMasterHostF[0], 'XLX_') === 0) && ($xlxMasterHost1 == $dmrMasterHostF[2])) { $xlxMasterHost1 = str_replace('_', ' ', $dmrMasterHostF[0]); }
+			if ((strpos($dmrMasterHostF[0], 'BM_') === 0) && ($dmrMasterHost1 == $dmrMasterHostF[2])) { $dmrMasterHost1 = str_replace('_', ' ', $dmrMasterHostF[0]); }
+			if ((strpos($dmrMasterHostF[0], 'DMR+_') === 0) && ($dmrMasterHost2 == $dmrMasterHostF[2])) { $dmrMasterHost2 = str_replace('_', ' ', $dmrMasterHostF[0]); }
 		}
 	}
 	if (strlen($xlxMasterHost1) > 21) { $xlxMasterHost1 = substr($xlxMasterHost1, 0, 19) . '..'; }


### PR DESCRIPTION
In case an identical IP is used for XLX/BM/DMR+ servers, for example:

root@mmdvm(rw):mmdvmhost# grep "193.93.24.29" /usr/local/etc/DMR_Hosts.txt
XLX_284				0000	193.93.24.29			passw0rd	62030
DMR+_2842_BULGARIA_TEST		2842	193.93.24.29			PASSWORD	55555

While resolving DMR Host 2 (DMR+), the XLX_284 will be shown instead of DMR+_2842_BULGARIA_TEST.

