### PR TITLE
don't log errors when config files doesn't exist

### DIFF
--- a/mmdvmhost/functions.php
+++ b/mmdvmhost/functions.php
@@ -2,7 +2,7 @@
 function getMMDVMConfig() {
 	// loads MMDVM.ini into array for further use
 	$conf = array();
-	if ($configs = fopen(MMDVMINIPATH."/".MMDVMINIFILENAME, 'r')) {
+	if ($configs = @fopen(MMDVMINIPATH."/".MMDVMINIFILENAME, 'r')) {
 		while ($config = fgets($configs)) {
 			array_push($conf, trim ( $config, " \t\n\r\0\x0B"));
 		}
@@ -14,7 +14,7 @@ function getMMDVMConfig() {
 function getYSFGatewayConfig() {
 	// loads MMDVM.ini into array for further use
 	$conf = array();
-	if ($configs = fopen(YSFGATEWAYINIPATH."/".YSFGATEWAYINIFILENAME, 'r')) {
+	if ($configs = @fopen(YSFGATEWAYINIPATH."/".YSFGATEWAYINIFILENAME, 'r')) {
 		while ($config = fgets($configs)) {
 			array_push($conf, trim ( $config, " \t\n\r\0\x0B"));
 		}
@@ -26,7 +26,7 @@ function getYSFGatewayConfig() {
 function getP25GatewayConfig() {
 	// loads MMDVM.ini into array for further use
 	$conf = array();
-	if ($configs = fopen(P25GATEWAYINIPATH."/".P25GATEWAYINIFILENAME, 'r')) {
+	if ($configs = @fopen(P25GATEWAYINIPATH."/".P25GATEWAYINIFILENAME, 'r')) {
 		while ($config = fgets($configs)) {
 			array_push($conf, trim ( $config, " \t\n\r\0\x0B"));
 		}
@@ -38,7 +38,7 @@ function getP25GatewayConfig() {
 function getNXDNGatewayConfig() {
 	// loads MMDVM.ini into array for further use
 	$conf = array();
-	if ($configs = fopen('/etc/nxdngateway', 'r')) {
+	if ($configs = @fopen('/etc/nxdngateway', 'r')) {
 		while ($config = fgets($configs)) {
 			array_push($conf, trim ( $config, " \t\n\r\0\x0B"));
 		}


### PR DESCRIPTION
Specially important here as this file is called very frequently while dashboard is in use. After yesterday nxdn changes if user didn't upgrade pistar yet then haves no /etc/nxdngateway yet, then it will log tons of errors on ngix log until /var/log fs is full (after just a few hours) and things start to fail (ircddbgateway crashes, etc)...