### PR TITLE
disable config page submit buttons after user clicks them

### DIFF
--- a/admin/configure.php
+++ b/admin/configure.php
@@ -126,12 +126,23 @@ $MYCALL=strtoupper($callsign);
     <title><?php echo "$MYCALL"." - ".$lang['digital_voice']." ".$lang['dashboard']." - ".$lang['configuration'];?></title>
     <link rel="stylesheet" type="text/css" href="css/ircddb.css?version=1.3" />
     <script type="text/javascript">
+	function disablesubmitbuttons()
+	{
+	  var inputs = document.getElementsByTagName('input');
+	  for (var i = 0; i < inputs.length; i++) {
+	    if (inputs[i].type === 'button') {
+	        inputs[i].disabled = true;
+	    }
+	  }
+	}
 	function submitform()
 	{
+	  disablesubmitbuttons();
 	  document.getElementById("config").submit();
 	}
 	function submitPassform()
 	{
+	  disablesubmitbuttons();
 	  document.getElementById("adminPassForm").submit();
 	}
 	function factoryReset()


### PR DESCRIPTION
to make sure user doesn't submit multiple times while waiting request to complete... I help a friend that got corrupted/missing config files two times now and I suspect the cause may be that he may click the apply buttons multiple times...