### PR TITLE
dashboard performance enhancements

### DIFF
--- a/dstarrepeater/system.php
+++ b/dstarrepeater/system.php
@@ -1,5 +1,6 @@
 <?php include_once $_SERVER['DOCUMENT_ROOT'].'/config/ircddblocal.php';
 include_once $_SERVER['DOCUMENT_ROOT'].'/config/language.php';	      // Translation Code
+include_once $_SERVER['DOCUMENT_ROOT'].'/mmdvmhost/tools.php';
 $configs = array();
 
 if ($configfile = fopen($gatewayConfigPath,'r')) {
@@ -44,20 +45,20 @@ if ($cpuTempC >= 69) { $cpuTempHTML = "<td style=\"background: #f00\">".$cpuTemp
     <th colspan="6"><?php echo $lang['service_status'];?></th>
   </tr>
   <tr>
-    <td style="background: #<?php exec ("pgrep MMDVMHost", $mmdvmhostpid); if (!empty($mmdvmhostpid)) { echo "1d1"; } else { echo "b55"; } ?>">MMDVMHost</td>
-    <td style="background: #<?php exec ("pgrep DMRGateway", $dmrgatewaypid); if (!empty($dmrgatewaypid)) { echo "1d1"; } else { echo "b55"; } ?>">DMRGateway</td>
-    <td style="background: #<?php exec ("pgrep YSFGateway", $ysfgatewaypid); if (!empty($ysfgatewaypid)) { echo "1d1"; } else { echo "b55"; } ?>">YSFGateway</td>
-    <td style="background: #<?php exec ("pgrep YSFParrot", $ysfparrotpid); if (!empty($ysfparrotpid)) { echo "1d1"; } else { echo "b55"; } ?>">YSFParrot</td>
-    <td style="background: #<?php exec ("pgrep P25Gateway", $p25gatewaypid); if (!empty($p25gatewaypid)) { echo "1d1"; } else { echo "b55"; } ?>">P25Gateway</td>
-    <td style="background: #<?php exec ("pgrep P25Parrot", $p25parrotpid); if (!empty($p25parrotpid)) { echo "1d1"; } else { echo "b55"; } ?>">P25Parrot</td>
+    <td style="background: #<?php if (isProcessRunning('MMDVMHost')) { echo "1d1"; } else { echo "b55"; } ?>">MMDVMHost</td>
+    <td style="background: #<?php if (isProcessRunning('DMRGateway')) { echo "1d1"; } else { echo "b55"; } ?>">DMRGateway</td>
+    <td style="background: #<?php if (isProcessRunning('YSFGateway')) { echo "1d1"; } else { echo "b55"; } ?>">YSFGateway</td>
+    <td style="background: #<?php if (isProcessRunning('YSFParrot')) { echo "1d1"; } else { echo "b55"; } ?>">YSFParrot</td>
+    <td style="background: #<?php if (isProcessRunning('P25Gateway')) { echo "1d1"; } else { echo "b55"; } ?>">P25Gateway</td>
+    <td style="background: #<?php if (isProcessRunning('P25Parrot')) { echo "1d1"; } else { echo "b55"; } ?>">P25Parrot</td>
   </tr>
   <tr>
-    <td style="background: #<?php exec ("pgrep dstarrepeaterd", $dstarrepeaterpid); if (!empty($dstarrepeaterpid)) { echo "1d1"; } else { echo "b55"; } ?>">DStarRepeater</td>
-    <td style="background: #<?php exec ("pgrep ircddbgatewayd", $ircddbgatewaypid); if (!empty($ircddbgatewaypid)) { echo "1d1"; } else { echo "b55"; } ?>">ircDDBGateway</td>
-    <td style="background: #<?php exec ("pgrep timeserverd", $timeserverpid); if (!empty($timeserverpid)) { echo "1d1"; } else { echo "b55"; } ?>">TimeServer</td>
-    <td style="background: #<?php exec ("pgrep -f -a /usr/local/sbin/pistar-watchdog | sed '/pgrep/d'", $watchdogpid); if (!empty($watchdogpid)) { echo "1d1"; } else { echo "b55"; } ?>">PiStar-Watchdog</td>
-    <td style="background: #<?php exec ("pgrep -f -a /usr/local/sbin/pistar-remote | sed '/pgrep/d'", $remotepid); if (!empty($remotepid)) { echo "1d1"; } else { echo "b55"; } ?>">PiStar-Remote</td>
-    <td style="background: #<?php exec ("pgrep -f -a /usr/local/sbin/pistar-keeper | sed '/pgrep/d'", $keeperpid); if (!empty($keeperpid)) { echo "1d1"; } else { echo "b55"; } ?>">PiStar-Keeper</td>
+    <td style="background: #<?php if (isProcessRunning('dstarrepeaterd')) { echo "1d1"; } else { echo "b55"; } ?>">DStarRepeater</td>
+    <td style="background: #<?php if (isProcessRunning('ircddbgatewayd')) { echo "1d1"; } else { echo "b55"; } ?>">ircDDBGateway</td>
+    <td style="background: #<?php if (isProcessRunning('timeserverd')) { echo "1d1"; } else { echo "b55"; } ?>">TimeServer</td>
+    <td style="background: #<?php if (isProcessRunning('/usr/local/sbin/pistar-watchdog',true)) { echo "1d1"; } else { echo "b55"; } ?>">PiStar-Watchdog</td>
+    <td style="background: #<?php if (isProcessRunning('/usr/local/sbin/pistar-remote',true)) { echo "1d1"; } else { echo "b55"; } ?>">PiStar-Remote</td>
+    <td style="background: #<?php if (isProcessRunning('/usr/local/sbin/pistar-keeper',true)) { echo "1d1"; } else { echo "b55"; } ?>">PiStar-Keeper</td>
   </tr>
 </table>
 <br />

--- a/index.php
+++ b/index.php
@@ -71,9 +71,9 @@ if ($_SERVER["PHP_SELF"] == "/admin/index.php") {
 	echo '<div class="contentwide">'."\n";
 	echo '<script type="text/javascript">'."\n";
 	echo 'function reloadSysInfo(){'."\n";
-	echo '  $("#sysInfo").load("/dstarrepeater/system.php");'."\n";
+	echo '  $("#sysInfo").load("/dstarrepeater/system.php",function(){ setTimeout(reloadSysInfo,15000) });'."\n";
 	echo '}'."\n";
-	echo 'setInterval(function(){reloadSysInfo()}, 15000);'."\n";
+	echo 'setTimeout(reloadSysInfo,15000);'."\n";
 	echo '$(window).trigger(\'resize\');'."\n";
 	echo '</script>'."\n";
 	echo '<div id="sysInfo">'."\n";
@@ -90,9 +90,9 @@ if (file_exists('/etc/dstar-radio.mmdvmhost')) {
 	echo '<div class="nav">'."\n";					// Start the Side Menu
 	echo '<script type="text/javascript">'."\n";
 	echo 'function reloadRepeaterInfo(){'."\n";
-	echo '  $("#repeaterInfo").load("/mmdvmhost/repeaterinfo.php");'."\n";
+	echo '  $("#repeaterInfo").load("/mmdvmhost/repeaterinfo.php",function(){ setTimeout(reloadRepeaterInfo,1000) });'."\n";
 	echo '}'."\n";
-	echo 'setInterval(function(){reloadRepeaterInfo()}, 1000);'."\n";
+	echo 'setTimeout(reloadRepeaterInfo,1000);'."\n";
 	echo '$(window).trigger(\'resize\');'."\n";
 	echo '</script>'."\n";
 	echo '<div id="repeaterInfo">'."\n";
@@ -108,9 +108,9 @@ if (file_exists('/etc/dstar-radio.mmdvmhost')) {
 	if ($_SERVER["PHP_SELF"] == "/admin/index.php") { 		// Admin Only Option
 		echo '<script type="text/javascript">'."\n";
 		echo 'function reloadrefLinks(){'."\n";
-		echo '  $("#refLinks").load("/dstarrepeater/active_reflector_links.php");'."\n";
+		echo '  $("#refLinks").load("/dstarrepeater/active_reflector_links.php",function(){ setTimeout(reloadrefLinks,2500) });'."\n";
 		echo '}'."\n";
-		echo 'setInterval(function(){reloadrefLinks()}, 2500);'."\n";
+		echo 'setTimeout(reloadrefLinks,2500);'."\n";
 		echo '$(window).trigger(\'resize\');'."\n";
 		echo '</script>'."\n";
 		echo '<div id="refLinks">'."\n";
@@ -124,9 +124,9 @@ if (file_exists('/etc/dstar-radio.mmdvmhost')) {
 
         echo '<script type="text/javascript">'."\n";
         echo 'function reloadcssConnections(){'."\n";
-        echo '  $("#cssConnects").load("/dstarrepeater/css_connections.php");'."\n";
+        echo '  $("#cssConnects").load("/dstarrepeater/css_connections.php",function(){ setTimeout(reloadcssConnections,15000) });'."\n";
         echo '}'."\n";
-        echo 'setInterval(function(){reloadcssConnections()}, 15000);'."\n";
+        echo 'setTimeout(reloadcssConnections,15000);'."\n";
 	echo '$(window).trigger(\'resize\');'."\n";
         echo '</script>'."\n";
         echo '<div id="cssConnects">'."\n";
@@ -137,9 +137,9 @@ if (file_exists('/etc/dstar-radio.mmdvmhost')) {
 	if ($_SERVER["PHP_SELF"] == "/admin/index.php") { 		// Admin Only Option
 		echo '<script type="text/javascript">'."\n";
         	echo 'function reloadbmConnections(){'."\n";
-        	echo '  $("#bmConnects").load("/mmdvmhost/bm_links.php");'."\n";
+        	echo '  $("#bmConnects").load("/mmdvmhost/bm_links.php",function(){ setTimeout(reloadbmConnections,15000) });'."\n";
         	echo '}'."\n";
-        	echo 'setInterval(function(){reloadbmConnections()}, 15000);'."\n";
+        	echo 'setTimeout(reloadbmConnections,15000);'."\n";
 		echo '$(window).trigger(\'resize\');'."\n";
         	echo '</script>'."\n";
         	echo '<div id="bmConnects">'."\n";
@@ -151,10 +151,13 @@ if (file_exists('/etc/dstar-radio.mmdvmhost')) {
         }
 	echo '<script type="text/javascript">'."\n";
 	echo 'function reloadLocalTx(){'."\n";
-	echo '  $("#localTxs").load("/mmdvmhost/localtx.php");'."\n";
-	echo '  $("#lastHerd").load("/mmdvmhost/lh.php");'."\n";
+	echo '  $("#localTxs").load("/mmdvmhost/localtx.php",function(){ setTimeout(reloadLocalTx,1500) });'."\n";
 	echo '}'."\n";
-	echo 'setInterval(function(){reloadLocalTx()}, 1500);'."\n";
+	echo 'setTimeout(reloadLocalTx,1500);'."\n";
+	echo 'function reloadLastHerd(){'."\n";
+	echo '  $("#lastHerd").load("/mmdvmhost/lh.php",function(){ setTimeout(reloadLastHerd,1500) });'."\n";
+	echo '}'."\n";
+	echo 'setTimeout(reloadLastHerd,1500);'."\n";
 	echo '$(window).trigger(\'resize\');'."\n";
 	echo '</script>'."\n";
 	echo '<div id="lastHerd">'."\n";
@@ -171,9 +174,9 @@ if (file_exists('/etc/dstar-radio.mmdvmhost')) {
 	include 'dstarrepeater/gateway_software_config.php';		// dstarrepeater gateway config
 	echo '<script type="text/javascript">'."\n";
 	echo 'function reloadrefLinks(){'."\n";
-	echo '  $("#refLinks").load("/dstarrepeater/active_reflector_links.php");'."\n";
+	echo '  $("#refLinks").load("/dstarrepeater/active_reflector_links.php",function(){ setTimeout(reloadrefLinks,2500) });'."\n";
 	echo '}'."\n";
-	echo 'setInterval(function(){reloadrefLinks()}, 2500);'."\n";
+	echo 'setTimeout(reloadrefLinks,2500);'."\n";
 	echo '$(window).trigger(\'resize\');'."\n";
 	echo '</script>'."\n";
         echo '<br />'."\n";
@@ -188,9 +191,9 @@ if (file_exists('/etc/dstar-radio.mmdvmhost')) {
 
 	echo '<script type="text/javascript">'."\n";
         echo 'function reloadcssConnections(){'."\n";
-        echo '  $("#cssConnects").load("/dstarrepeater/css_connections.php");'."\n";
+        echo '  $("#cssConnects").load("/dstarrepeater/css_connections.php",function(){ setTimeout(reloadcssConnections,15000) });'."\n";
         echo '}'."\n";
-        echo 'setInterval(function(){reloadcssConnections()}, 15000);'."\n";
+        echo 'setTimeout(reloadcssConnections,15000);'."\n";
 	echo '$(window).trigger(\'resize\');'."\n";
         echo '</script>'."\n";
         echo '<div id="cssConnects">'."\n";
@@ -199,10 +202,13 @@ if (file_exists('/etc/dstar-radio.mmdvmhost')) {
 
 	echo '<script type="text/javascript">'."\n";
 	echo 'function reloadLocalTx(){'."\n";
-	echo '  $("#localTx").load("/dstarrepeater/local_tx.php");'."\n";
-	echo '  $("#lh").load("/dstarrepeater/last_herd.php");'."\n";
+	echo '  $("#localTx").load("/dstarrepeater/local_tx.php",function(){ setTimeout(reloadLocalTx,3000) });'."\n";
 	echo '}'."\n";
-	echo 'setInterval(function(){reloadLocalTx()}, 3000);'."\n";
+	echo 'setTimeout(reloadLocalTx,3000);'."\n";
+	echo 'function reloadLastHerd(){'."\n";
+	echo '  $("#lh").load("/dstarrepeater/last_herd.php",function(){ setTimeout(reloadLastHerd,3000) });'."\n";
+	echo '}'."\n";
+	echo 'setTimeout(reloadLastHerd,3000);'."\n";
 	echo '$(window).trigger(\'resize\');'."\n";
 	echo '</script>'."\n";
 	echo '<div id="lh">'."\n";

--- a/index.php
+++ b/index.php
@@ -84,7 +84,7 @@ if ($_SERVER["PHP_SELF"] == "/admin/index.php") {
 // First lets figure out if we are in MMDVMHost mode, or dstarrepeater mode;
 if (file_exists('/etc/dstar-radio.mmdvmhost')) {
 	include 'config/config.php';					// MMDVMDash Config
-	include 'mmdvmhost/tools.php';					// MMDVMDash Tools
+	include_once 'mmdvmhost/tools.php';					// MMDVMDash Tools
 	//include 'mmdvmhost/functions.php';				// MMDVMDash Functions
 
 	echo '<div class="nav">'."\n";					// Start the Side Menu

--- a/mmdvmhost/functions.php
+++ b/mmdvmhost/functions.php
@@ -951,20 +951,22 @@ function getName($callsign) {
 
 //Some basic inits
 $mmdvmconfigs = getMMDVMConfig();
-$logLinesMMDVM = getMMDVMLog();
-$reverseLogLinesMMDVM = $logLinesMMDVM;
-array_multisort($reverseLogLinesMMDVM,SORT_DESC);
-$lastHeard = getLastHeard($reverseLogLinesMMDVM);
-$YSFGatewayconfigs = getYSFGatewayConfig();
-$logLinesYSFGateway = getYSFGatewayLog();
-$reverseLogLinesYSFGateway = $logLinesYSFGateway;
-array_multisort($reverseLogLinesYSFGateway,SORT_DESC);
-$P25Gatewayconfigs = getP25GatewayConfig();
-$logLinesP25Gateway = getP25GatewayLog();
-$reverseLogLinesP25Gateway = $logLinesP25Gateway;
-array_multisort($reverseLogLinesP25Gateway,SORT_DESC);
-$NXDNGatewayconfigs = getNXDNGatewayConfig();
-$logLinesNXDNGateway = getNXDNGatewayLog();
-$reverseLogLinesNXDNGateway = $logLinesNXDNGateway;
-array_multisort($reverseLogLinesNXDNGateway,SORT_DESC);
+if (!in_array($_SERVER["PHP_SELF"],array('/mmdvmhost/bm_links.php','/mmdvmhost/bm_manager.php'),true)) {
+	$logLinesMMDVM = getMMDVMLog();
+	$reverseLogLinesMMDVM = $logLinesMMDVM;
+	array_multisort($reverseLogLinesMMDVM,SORT_DESC);
+	$lastHeard = getLastHeard($reverseLogLinesMMDVM);
+	$YSFGatewayconfigs = getYSFGatewayConfig();
+	$logLinesYSFGateway = getYSFGatewayLog();
+	$reverseLogLinesYSFGateway = $logLinesYSFGateway;
+	array_multisort($reverseLogLinesYSFGateway,SORT_DESC);
+	$P25Gatewayconfigs = getP25GatewayConfig();
+	$logLinesP25Gateway = getP25GatewayLog();
+	$reverseLogLinesP25Gateway = $logLinesP25Gateway;
+	array_multisort($reverseLogLinesP25Gateway,SORT_DESC);
+	$NXDNGatewayconfigs = getNXDNGatewayConfig();
+	$logLinesNXDNGateway = getNXDNGatewayLog();
+	$reverseLogLinesNXDNGateway = $logLinesNXDNGateway;
+	array_multisort($reverseLogLinesNXDNGateway,SORT_DESC);
+}
 ?>

--- a/mmdvmhost/repeaterinfo.php
+++ b/mmdvmhost/repeaterinfo.php
@@ -66,7 +66,7 @@ if (isset($lastHeard[0])) {
 	                echo "<td style=\"background:#0b0; color:#030;\">Listening</td>";
 	                }
 	        elseif (getActualMode($lastHeard, $mmdvmconfigs) === NULL) {
-	                exec ("pgrep MMDVMHost", $mmdvmhostpid); if (!empty($mmdvmhostpid)) { echo "<td style=\"background:#0b0; color:#030;\">Listening</td>"; } else { echo "<td style=\"background:#606060; color:#b0b0b0;\">OFFLINE</td>"; }
+	                if (isProcessRunning("MMDVMHost")) { echo "<td style=\"background:#0b0; color:#030;\">Listening</td>"; } else { echo "<td style=\"background:#606060; color:#b0b0b0;\">OFFLINE</td>"; }
 	                }
 	        elseif ($listElem[2] && $listElem[6] == null && getActualMode($lastHeard, $mmdvmconfigs) === 'D-Star') {
 	                echo "<td style=\"background:#4aa361;\">RX D-Star</td>";

--- a/mmdvmhost/tools.php
+++ b/mmdvmhost/tools.php
@@ -33,15 +33,23 @@ function getMHZ($freq) {
 	return substr($freq,0,3) . "." . substr($freq,3,6) . " MHz";
 }
 
-function isProcessRunning($processname) {
-	exec("pgrep " . $processname, $pids);
-	if(empty($pids)) {
-	    // process not running!
-	    return false;
-	} else {
-		// process running!
-		return true;
-	}
+function isProcessRunning($processName, $full = false, $refresh = false) {
+  if ($full) {
+    static $processes_full = array();
+    if ($refresh) $processes_full = array();
+    if (empty($processes_full))
+      exec('ps -eo args', $processes_full);
+  } else {
+    static $processes = array();
+    if ($refresh) $processes = array();
+    if (empty($processes))
+      exec('ps -eo comm', $processes);
+  }
+  foreach (($full ? $processes_full : $processes) as $processString) {
+    if (strpos($processString, $processName) !== false)
+      return true;
+  }
+  return false;
 }
 
 function createConfigLines() { 


### PR DESCRIPTION
Some performance enhancements so that pages are faster and use less cpu resources at server. The changes make considerable difference mainly when there are multiple DV modes enabled simultaneously (more pgrep checks).

Benchmark of request times before and after the changes:
repeaterinfo.php: 1.6s -> 436ms
system.php: 1.2s -> 330ms
bm_links.php: 843ms -> 534ms
admin/: 3.49s -> 1.60s
(measured on RPi2, with all DV modes enabled, guess it should make even more difference on RPi0...)