### PR TITLE
fix 'Trx' to show correct status

### DIFF
--- a/mmdvmhost/functions.php
+++ b/mmdvmhost/functions.php
@@ -641,6 +641,11 @@ function getActualMode($metaLastHeard, $mmdvmconfigs) {
 		}
 		$timestamp->add(new DateInterval('PT' . $hangtime . 'S'));
 	}
+	if ($listElem[6] != null) { //if terminated, hangtime counts after end of transmission
+		$timestamp->add(new DateInterval('PT' . ceil($listElem[6]) . 'S'));
+	} else { //if not terminated, always return mode
+		return $mode;
+	}
 	if ($now->format('U') > $timestamp->format('U')) {
 		return "idle";
 	} else {


### PR DESCRIPTION
without this patch it would show 'Listening' after hangtime elapsed even during RF transmission and would also not show correct mode hangtime starting to count after end of transmission as it should (for both RF/Net), it was instead incorrectly doing it based on start of transmission time...