### PR TITLE
improve showing actual ysf room

### DIFF
--- a/mmdvmhost/functions.php
+++ b/mmdvmhost/functions.php
@@ -801,7 +801,7 @@ function getActualLink($logLines, $mode) {
 	// M: 2016-09-25 16:08:05.811 Connect to 62829 has been requested by DG9VH
 	// M: 2016-10-01 17:52:36.586 Automatic connection to 62829
 	// New YSFGateway Format
-	// M: 2018-03-06 15:36:06.344 Linked to GB SOUTH WEST
+	// M: 2018-03-06 15:36:06.344 Linked to GB SOUTH WEST   
 	// M: 2018-03-06 15:36:06.302 Automatic (re-)connection to 16710 - "GB SOUTH WEST   "
 	// M: 2018-05-03 13:02:36.904 Disconnect via DTMF has been requested by MW0MWZ
 		
@@ -809,7 +809,7 @@ function getActualLink($logLines, $mode) {
             $to = "";
             foreach($logLines as $logLine) {
 	       if ( (strpos($logLine,"Linked to")) && (!strpos($logLine,"Linked to MMDVM")) ) {
-                  $to = substr($logLine, 37, 15); 
+                  $to = trim(substr($logLine, 37, 16));
                }
 	       if (strpos($logLine,"Automatic (re-)connection to")) {
                   $to = substr($logLine, 56, 5);

--- a/mmdvmhost/repeaterinfo.php
+++ b/mmdvmhost/repeaterinfo.php
@@ -215,12 +215,13 @@ if ( $testMMDVModeYSF == 1 ) { //Hide the YSF information when System Fusion Net
         while (!feof($ysfHostFile)) {
                 $ysfHostFileLine = fgets($ysfHostFile);
                 $ysfRoomTxtLine = preg_split('/;/', $ysfHostFileLine);
-                if ($ysfRoomTxtLine[0] == $ysfLinkedTo) {
+                if (($ysfRoomTxtLine[0] == $ysfLinkedTo) || ($ysfRoomTxtLine[1] == $ysfLinkedTo)) {
                         $ysfLinkedToTxt = $ysfRoomTxtLine[1];
+                        break;
                 }
-		if ($ysfLinkedTo == "00002") {
-			$ysfLinkedToTxt = "YSF2DMR";
-		}
+        }
+        if ($ysfLinkedTo == "00002") {
+                $ysfLinkedToTxt = "YSF2DMR";
         }
         if ($ysfLinkedToTxt != "null") { $ysfLinkedToTxt = "Room: ".$ysfLinkedToTxt; } else { $ysfLinkedToTxt = "Linked to: ".$ysfLinkedTo; }
         $ysfLinkedToTxt = str_replace('_', ' ', $ysfLinkedToTxt);

--- a/mmdvmhost/repeaterinfo.php
+++ b/mmdvmhost/repeaterinfo.php
@@ -220,9 +220,6 @@ if ( $testMMDVModeYSF == 1 ) { //Hide the YSF information when System Fusion Net
                         break;
                 }
         }
-        if ($ysfLinkedTo == "00002") {
-                $ysfLinkedToTxt = "YSF2DMR";
-        }
         if ($ysfLinkedToTxt != "null") { $ysfLinkedToTxt = "Room: ".$ysfLinkedToTxt; } else { $ysfLinkedToTxt = "Linked to: ".$ysfLinkedTo; }
         $ysfLinkedToTxt = str_replace('_', ' ', $ysfLinkedToTxt);
         if (strlen($ysfLinkedToTxt) > 21) { $ysfLinkedToTxt = substr($ysfLinkedToTxt, 0, 19) . '..'; }


### PR DESCRIPTION
i.e. restore it to behave as before the new ysfgateway, showing rooms as "Room: " (actually maybe this could be rewritten in other way... as in these messages we already know the room name really... but you also need to support searching for room number for other messages anyway... then I did just change it to search both exactly as you did on the config page...). Also added break after finding the room and moved the 00002 check to out of the while for efficiency...

Trimming blank padding spaces from getActualLink ysf room name is important else it always exceeds the 21 chars and gets truncated to 19 with ".." appended (on repeaterinfo.php)...

Both results in showing something like "Linked to: PT YSF00" currently :(