### PR TITLE
fix for getActualLink() sometimes not returning correct "not linked" status for ysf

### DIFF
--- a/mmdvmhost/functions.php
+++ b/mmdvmhost/functions.php
@@ -808,10 +808,10 @@ function getActualLink($logLines, $mode) {
          if (isProcessRunning("YSFGateway")) {
             $to = "";
             foreach($logLines as $logLine) {
-	       if ( (strpos($logLine,"Linked to")) && (!strpos($logLine,"Linked to MMDVM")) ) {
+               if ( (strpos($logLine,"Linked to")) && (!strpos($logLine,"Linked to MMDVM")) ) {
                   $to = trim(substr($logLine, 37, 16));
                }
-	       if (strpos($logLine,"Automatic (re-)connection to")) {
+               if (strpos($logLine,"Automatic (re-)connection to")) {
                   $to = substr($logLine, 56, 5);
                }
                if (strpos($logLine,"Connect to")) {
@@ -823,17 +823,14 @@ function getActualLink($logLines, $mode) {
                if (strpos($logLine,"Disconnect via DTMF")) {
                   $to = "not linked";
                }
-               if ($to !== "") {
-                  return $to;
-               }
-               if (strpos($logLine,"Linked to MMDVM")) {
-                  continue;
-               }
                if (strpos($logLine,"Starting YSFGateway-")) {
                   $to = "not linked";
                }
                if (strpos($logLine,"DISCONNECT Reply")) {
                   $to = "not linked";
+               }
+               if ($to !== "") {
+                  return $to;
                }
             }
             return "not linked";


### PR DESCRIPTION
The "not linked" status for the "Starting YSFGateway-" and "DISCONNECT Reply" checks was being overridden on the next 'for' cycle if one of the above checks match the next (i.e. previous as it is reversed) log entry, thus sometimes incorrectly showing previously linked Room. Also the check for "Linked to MMDVM" to 'continue' the 'for' cycle to the next log line seems just useless there...

Example ysfgateway log file that will trigger unpatched code to incorrectly show previously linked Room:
```
M: 2018-05-11 02:55:33.454 Opening YSF network connection
I: 2018-05-11 02:55:33.454 Opening UDP port on 4200
M: 2018-05-11 02:55:33.455 Opening YSF network connection
I: 2018-05-11 02:55:33.455 Opening UDP port on 42000
M: 2018-05-11 02:55:33.455 Resolving FCS00x addresses
M: 2018-05-11 02:55:33.520 Opening FCS network connection
I: 2018-05-11 02:55:33.520 Opening UDP port on 42001
I: 2018-05-11 02:55:33.521 The ID of this repeater is 44191
I: 2018-05-11 02:55:33.523 Loaded 229 FCS room descriptions
I: 2018-05-11 02:55:38.011 Loaded 255 YSF reflectors
I: 2018-05-11 02:55:38.011 Loaded YSF parrot
I: 2018-05-11 02:55:38.011 Loaded YSF2DMR
I: 2018-05-11 02:55:38.011 Loaded YSF2NXDN
I: 2018-05-11 02:55:38.011 Loaded YSF2P25
M: 2018-05-11 02:55:38.040 Automatic (re-)connection to 00002 - "YSF2DMR         "
M: 2018-05-11 02:55:38.041 Starting YSFGateway-20180509_Pi-Star
M: 2018-05-11 02:55:40.255 Linked to MMDVM
M: 2018-05-11 02:55:40.495 Linked to YSF2DMR         
M: 2018-05-11 02:56:12.540 Opening YSF network connection
I: 2018-05-11 02:56:12.541 Opening UDP port on 4200
M: 2018-05-11 02:56:12.541 Opening YSF network connection
I: 2018-05-11 02:56:12.541 Opening UDP port on 42000
M: 2018-05-11 02:56:12.541 Resolving FCS00x addresses
M: 2018-05-11 02:56:12.577 Opening FCS network connection
I: 2018-05-11 02:56:12.577 Opening UDP port on 42001
I: 2018-05-11 02:56:12.577 The ID of this repeater is 44191
I: 2018-05-11 02:56:12.579 Loaded 229 FCS room descriptions
I: 2018-05-11 02:56:14.091 Loaded 255 YSF reflectors
I: 2018-05-11 02:56:14.091 Loaded YSF parrot
I: 2018-05-11 02:56:14.092 Loaded YSF2DMR
I: 2018-05-11 02:56:14.092 Loaded YSF2NXDN
I: 2018-05-11 02:56:14.092 Loaded YSF2P25
M: 2018-05-11 02:56:14.175 Starting YSFGateway-20180509_Pi-Star
M: 2018-05-11 02:56:20.624 Linked to MMDVM
```