### PR TITLE
ignore empty lines on ysf hosts file and avoid logging php errors

### DIFF
--- a/admin/configure.php
+++ b/admin/configure.php
@@ -738,10 +738,10 @@ if ($_SERVER["PHP_SELF"] == "/admin/configure.php") {
 	  //if ($newYSFStartupHost == "NONE") { unset($configysfgateway['Network']['Startup']); }
 	  //else { $configysfgateway['Network']['Startup'] = $newYSFStartupHost; }
 	  if (isset($configysfgateway['FCS Network'])) {
-		if ($newYSFStartupHostArr[0] == "NONE") { unset($configysfgateway['Network']['Startup']); }
+		if ($newYSFStartupHostArr[0] == "none") { unset($configysfgateway['Network']['Startup']); }
 	  	else { $configysfgateway['Network']['Startup'] = $newYSFStartupHostArr[1]; }
 	  } else {
-	  	if ($newYSFStartupHostArr[0] == "NONE") { unset($configysfgateway['Network']['Startup']); }
+	  	if ($newYSFStartupHostArr[0] == "none") { unset($configysfgateway['Network']['Startup']); }
 	  	else { $configysfgateway['Network']['Startup'] = $newYSFStartupHostArr[0]; }
 	  }
 	}

--- a/mmdvmhost/repeaterinfo.php
+++ b/mmdvmhost/repeaterinfo.php
@@ -215,6 +215,7 @@ if ( $testMMDVModeYSF == 1 ) { //Hide the YSF information when System Fusion Net
         while (!feof($ysfHostFile)) {
                 $ysfHostFileLine = fgets($ysfHostFile);
                 $ysfRoomTxtLine = preg_split('/;/', $ysfHostFileLine);
+                if (empty($ysfRoomTxtLine[0]) || empty($ysfRoomTxtLine[1])) continue;
                 if (($ysfRoomTxtLine[0] == $ysfLinkedTo) || ($ysfRoomTxtLine[1] == $ysfLinkedTo)) {
                         $ysfLinkedToTxt = $ysfRoomTxtLine[1];
                         break;


### PR DESCRIPTION
- currently it is filling nginx log file every second or so with notices of undefined offsets trying to access splited values on the lines below :( triggered by a blank line at end of the hosts file... better to ignore these lines with empty room number/name...

- check ysf room setting on configuration page for lower case 'none' as posted by the form - also causing undefined offset php notices, as 'none' is being handled as if it was a room name and expecting to split number/name...