### PR TITLE
improve getActualLink() yet again for ysf

### DIFF
--- a/mmdvmhost/functions.php
+++ b/mmdvmhost/functions.php
@@ -823,7 +823,7 @@ function getActualLink($logLines, $mode) {
                if (strpos($logLine,"Disconnect via DTMF")) {
                   $to = "not linked";
                }
-               if (strpos($logLine,"Starting YSFGateway-")) {
+               if (strpos($logLine,"Opening YSF network connection")) {
                   $to = "not linked";
                }
                if (strpos($logLine,"DISCONNECT Reply")) {


### PR DESCRIPTION
After analyzing YSFGateway code, looking at a few different logs, and even taking into account older YSFGateway versions... I think it's better we rely on the "Opening YSF network connection" log message to identify YSFGateway startup/restart, because auto connection messages (when a Startup host is set) are logged before the "Starting YSFGateway-" one (now I can fully understand why you had that code to allow relying on previous log line for that message... but it was surely not perfect also because it could incorrectly show previously linked room after YSFGateway restart - the reason for my PR early today).