### PR TITLE
don't replace 'ignore_broadcast_ssid=' line to 'ssid='

### DIFF
--- a/admin/configure.php
+++ b/admin/configure.php
@@ -1338,7 +1338,7 @@ if ($_SERVER["PHP_SELF"] == "/admin/configure.php") {
 	  system($rollMotd);
 	  if (file_exists('/etc/hostapd/hostapd.conf')) {
 		  // Update the Hotspot name to the Hostname
-		  $rollApSsid = 'sudo sed -i "/ssid=/c\\ssid='.$newHostnameLower.'" /etc/hostapd/hostapd.conf';
+		  $rollApSsid = 'sudo sed -i "/^ssid=/c\\ssid='.$newHostnameLower.'" /etc/hostapd/hostapd.conf';
 		  system($rollApSsid);
 	  }
 	}


### PR DESCRIPTION
Currently when applying changes on the configuration page causes the 'ignore_broadcast_ssid=' line on hostapd.conf to be wrongly replaced by a 2nd 'ssid=' line.