### PR TITLE
only start pistar-upnp.service if enabled

### DIFF
--- a/admin/config_backup.php
+++ b/admin/config_backup.php
@@ -184,7 +184,9 @@ if ($_SERVER["PHP_SELF"] == "/admin/config_backup.php") {
 			shell_exec('sudo systemctl start timeserver.service 2>&1');		//Time Server Service
 			shell_exec('sudo systemctl start pistar-watchdog.service 2>&1');	//PiStar-Watchdog Service
 			shell_exec('sudo systemctl start pistar-remote.service 2>&1');		//PiStar-Remote Service
-			shell_exec('sudo systemctl start pistar-upnp.service 2>&1');		//PiStar-UPnP Service
+			if (substr(exec('grep "pistar-upnp.service" /etc/crontab | cut -c 1'), 0, 1) !== '#') {
+				shell_exec('sudo systemctl start pistar-upnp.service 2>&1');		//PiStar-UPnP Service
+			}
 			shell_exec('sudo systemctl start ysfgateway.service 2>&1');		//YSFGateway
 			shell_exec('sudo systemctl start ysf2dmr.service 2>&1');		//YSF2DMR
 			shell_exec('sudo systemctl start p25gateway.service 2>&1');		//P25Gateway

--- a/admin/configure.php
+++ b/admin/configure.php
@@ -1819,7 +1819,9 @@ if ($_SERVER["PHP_SELF"] == "/admin/configure.php") {
 	system('sudo systemctl start timeserver.service > /dev/null 2>/dev/null &');		// Time Server Service
 	system('sudo systemctl start pistar-watchdog.service > /dev/null 2>/dev/null &');	// PiStar-Watchdog Service
 	system('sudo systemctl start pistar-remote.service > /dev/null 2>/dev/null &');		// PiStar-Remote Service
-	system('sudo systemctl start pistar-upnp.service > /dev/null 2>/dev/null &');		// PiStar-UPnP Service
+	if (empty($_POST['uPNP']) != TRUE ) {
+		if (escapeshellcmd($_POST['uPNP']) == 'ON' ) { system('sudo systemctl start pistar-upnp.service > /dev/null 2>/dev/null &'); }
+	}
 	system('sudo systemctl start ysf2dmr.service > /dev/null 2>/dev/null &');		// YSF2DMR
 	system('sudo systemctl start ysf2nxdn.service > /dev/null 2>/dev/null &');		// YSF2NXDN
 	system('sudo systemctl start ysf2p25.service > /dev/null 2>/dev/null &');		// YSF2P25


### PR DESCRIPTION
- when applying settings on configuration page
- when restoring config backup