### PR TITLE
Allow DMR and YSF2DMR turned on

### DIFF
--- a/admin/configure.php
+++ b/admin/configure.php
@@ -1336,7 +1336,7 @@ if ($_SERVER["PHP_SELF"] == "/admin/configure.php") {
 
 	// Set YSF2DMR Mode
 	if (empty($_POST['MMDVMModeYSF2DMR']) != TRUE ) {
-          if (escapeshellcmd($_POST['MMDVMModeYSF2DMR']) == 'ON' )  { $configysf2dmr['Enabled']['Enabled'] = "1"; $configmmdvm['DMR']['Enable'] = "0"; $configmmdvm['DMR Network']['Enable'] = "0";}
+          if (escapeshellcmd($_POST['MMDVMModeYSF2DMR']) == 'ON' )  { $configysf2dmr['Enabled']['Enabled'] = "1"; }
           if (escapeshellcmd($_POST['MMDVMModeYSF2DMR']) == 'OFF' ) { $configysf2dmr['Enabled']['Enabled'] = "0"; }
 	}
 


### PR DESCRIPTION
YSF2DMR connects directly to DMR master and not to DMRGateway, also we can even use different ID to be able to use both at same time with no problem at all... I don't see a reason to disallow both to be enabled at same time as before?