### PR TITLE
dplusLogin should be space padded to 8 characters

### DIFF
--- a/admin/configure.php
+++ b/admin/configure.php
@@ -717,7 +717,7 @@ if ($_SERVER["PHP_SELF"] == "/admin/configure.php") {
 	  $newCallsignUpperIRC = $newCallsignUpper;
 
 	  $rollGATECALL = 'sudo sed -i "/gatewayCallsign=/c\\gatewayCallsign='.$newCallsignUpper.'" /etc/ircddbgateway';
-	  $rollDPLUSLOGIN = 'sudo sed -i "/dplusLogin=/c\\dplusLogin='.$newCallsignUpper.'" /etc/ircddbgateway';
+	  $rollDPLUSLOGIN = 'sudo sed -i "/dplusLogin=/c\\dplusLogin='.str_pad($newCallsignUpper, 8, " ").'" /etc/ircddbgateway';
 	  $rollDASHBOARDcall = 'sudo sed -i "/callsign=/c\\$callsign=\''.$newCallsignUpper.'\';" /var/www/dashboard/config/ircddblocal.php';
 	  $rollTIMESERVERcall = 'sudo sed -i "/callsign=/c\\callsign='.$newCallsignUpper.'" /etc/timeserver';
 	  $rollSTARNETSERVERcall = 'sudo sed -i "/callsign=/c\\callsign='.$newCallsignUpper.'" /etc/starnetserver';


### PR DESCRIPTION
... like done by ircDDBGatewayConfig (gui version). The missing spaces cause problems like being unable to use DPlus on (at least) XLX reflectors (symptom: unable to "acquire" module, even after 1st TX, and despite we can listen at others we can't be heard by anyone)