### PR TITLE
/etc/crontab should always be written with Un*x line endings by fulledit_cron.php

### DIFF
--- a/admin/expert/fulledit_cron.php
+++ b/admin/expert/fulledit_cron.php
@@ -40,7 +40,7 @@ if(isset($_POST['data'])) {
         // Open the file and write the data
         $filepath = '/tmp/a8h4d8n3c83h4.tmp';
         $fh = fopen($filepath, 'w');
-        fwrite($fh, $_POST['data']);
+        fwrite($fh, str_replace("\r", "", $_POST['data']));
         fclose($fh);
         exec('sudo mount -o remount,rw /');
         exec('sudo cp /tmp/a8h4d8n3c83h4.tmp /etc/crontab');


### PR DESCRIPTION
For me it turned out that cron jobs didn't work at all after editing `/etc/crontab`  via `admin/expert/fulledit_cron.php`. Editing was done in a Webbrowser running on Windows (Linux not tested).

Reason was found as `/etc/crontab` having DOS line endings. After `dos2unix /etc/crontab` it started working again.

This merge request should ensure to convert line endings in the posted data to Un*x format before writing it to `/etc/crontab`.