### PR TITLE
Rework LastHeard to prevent RF & Net traffic conflicts

### DIFF
--- a/mmdvmhost/functions.php
+++ b/mmdvmhost/functions.php
@@ -678,8 +678,9 @@ function getLastHeard($logLines) {
 	$counter = 0;
 	foreach ($heardList as $listElem) {
 		if ( ($listElem[1] == "D-Star") || ($listElem[1] == "YSF") || ($listElem[1] == "P25") || ($listElem[1] == "NXDN") || ($listElem[1] == "POCSAG") || (startsWith($listElem[1], "DMR")) ) {
-			if(!(array_search($listElem[2]."#".$listElem[1].$listElem[3], $heardCalls) > -1)) {
-				array_push($heardCalls, $listElem[2]."#".$listElem[1].$listElem[3]);
+			$callUuid = $listElem[2]."#".$listElem[1].$listElem[3].$listElem[5];
+			if(!(array_search($callUuid, $heardCalls) > -1)) {
+				array_push($heardCalls, $callUuid);
 				array_push($lastHeard, $listElem);
 				$counter++;
 			}/*


### PR DESCRIPTION
This PR fixes an issue that causes local RF traffic to disappear from the dashboard after a user uses a different repeater on the same talkgroup. The call source (RF vs Net) is now stored along with the source, destination, and timeslot. 