### PR TITLE
Add support for Hotspot ID:

### DIFF
--- a/admin/config_backup.php
+++ b/admin/config_backup.php
@@ -62,6 +62,9 @@ if ($_SERVER["PHP_SELF"] == "/admin/config_backup.php") {
 	  if (shell_exec('cat /etc/dhcpcd.conf | grep "static ip_address" | grep -v "#"')) {
 		  $output .= shell_exec("sudo cp /etc/dhcpcd.conf $backupDir 2>&1");
 	  }
+          if (file_exists('/etc/hotspot_id')) {
+	          $output .= shell_exec("sudo cp /etc/hotspot_id $backupDir 2>&1");
+	  }
           $output .= shell_exec("sudo cp /etc/wpa_supplicant/wpa_supplicant.conf $backupDir 2>&1");
           $output .= shell_exec("sudo cp /etc/ircddbgateway $backupDir 2>&1");
           $output .= shell_exec("sudo cp /etc/mmdvmhost $backupDir 2>&1");

--- a/admin/configure.php
+++ b/admin/configure.php
@@ -1113,6 +1113,12 @@ if ($_SERVER["PHP_SELF"] == "/admin/configure.php") {
 	  if (escapeshellcmd($_POST['dmrGatewayNet2En']) == 'OFF' ) { $configdmrgateway['DMR Network 2']['Enabled'] = "0"; }
 	}
 
+	// Set the DMRGateway Network 1 On or Off
+	if (empty($_POST['dmrGatewayNet1En']) != TRUE ) {
+	  if (escapeshellcmd($_POST['dmrGatewayNet1En']) == 'ON' ) { $configdmrgateway['DMR Network 1']['Enabled'] = "1"; }
+	  if (escapeshellcmd($_POST['dmrGatewayNet1En']) == 'OFF' ) { $configdmrgateway['DMR Network 1']['Enabled'] = "0"; }
+	}
+
 	// Remove old settings
 	if (isset($configmmdvm['General']['ModeHang'])) { unset($configmmdvm['General']['ModeHang']); }
 	if (isset($configdmrgateway['General']['Timeout'])) { unset($configdmrgateway['General']['Timeout']); }
@@ -2973,6 +2979,7 @@ else:
     <input type="hidden" name="dmrEmbeddedLCOnly" value="OFF" />
     <input type="hidden" name="dmrDumpTAData" value="OFF" />
     <input type="hidden" name="dmrGatewayXlxEn" value="OFF" />
+    <input type="hidden" name="dmrGatewayNet1En" value="OFF" />
     <input type="hidden" name="dmrGatewayNet2En" value="OFF" />
     <input type="hidden" name="dmrDMRnetJitterBufer" value="OFF" />
     <table>
@@ -3019,6 +3026,13 @@ else:
     <td align="left"><a class="tooltip2" href="#">BrandMeister Password:<span><b>BrandMeister Password</b>Override the Password for BrandMeister</span></a></td>
     <td align="left"><input type="text" name="bmPasswordOverride" size="30" maxlength="30" value="<?php echo $configdmrgateway['DMR Network 1']['Password']; ?>"></input></td>
     </tr> -->
+    <tr>
+    <td align="left"><a class="tooltip2" href="#"><?php echo $lang['bm_network'];?> Enable:<span><b>BrandMeister Network Enable</b></span></a></td>
+    <td align="left">
+    <?php if ($configdmrgateway['DMR Network 1']['Enabled'] == 1) { echo "<div class=\"switch\"><input id=\"toggle-dmrGatewayNet1En\" class=\"toggle toggle-round-flat\" type=\"checkbox\" name=\"dmrGatewayNet1En\" value=\"ON\" checked=\"checked\" /><label for=\"toggle-dmrGatewayNet1En\"></label></div>\n"; }
+    else { echo "<div class=\"switch\"><input id=\"toggle-dmrGatewayNet1En\" class=\"toggle toggle-round-flat\" type=\"checkbox\" name=\"dmrGatewayNet1En\" value=\"ON\" /><label for=\"toggle-dmrGatewayNet1En\"></label></div>\n"; } ?>
+    </td>
+    </tr>
     <tr>
     <td align="left"><a class="tooltip2" href="#"><?php echo $lang['bm_network'];?>:<span><b>BrandMeister Dashboards</b>Direct links to your BrandMeister Dashboards</span></a></td>
     <td>

--- a/admin/configure.php
+++ b/admin/configure.php
@@ -931,6 +931,10 @@ if ($_SERVER["PHP_SELF"] == "/admin/configure.php") {
 	// Set DMR / CCS7 ID
 	if (empty($_POST['dmrId']) != TRUE ) {
 	  $newPostDmrId = preg_replace('/[^0-9]/', '', $_POST['dmrId']);
+	  $hotspotId = (strlen($_POST['hotspotId'])) ? $_POST['hotspotId'] : '-1';
+	  $hotspotId = ((((intval($hotspotId) >= 0) && (intval($hotspotId <= 9))) || (intval($hotspotId) == -1)) ? $hotspotId : '-1');
+	  $ccs7extra = ((intval($hotspotId) != -1) ? $hotspotId : '');
+	  
 	  //$configmmdvm['DMR']['Id'] = $newPostDmrId;
 	  unset($configmmdvm['DMR']['Id']);
 	  if (empty($_POST['dmrMasterHost']) != TRUE ) {
@@ -941,7 +945,8 @@ if ($_SERVER["PHP_SELF"] == "/admin/configure.php") {
 	  $configysfgateway['General']['Id'] = $newPostDmrId;
 	  $configdmrgateway['XLX Network']['Id'] = substr($newPostDmrId,0,7);
 	  $configdmrgateway['XLX Network 1']['Id'] = substr($newPostDmrId,0,7);
-	  $configdmrgateway['DMR Network 2']['Id'] = substr($newPostDmrId,0,7);
+	  $configdmrgateway['DMR Network 1']['Id'] = substr($newPostDmrId.$ccs7extra,0);
+	  $configdmrgateway['DMR Network 2']['Id'] = substr($newPostDmrId.$ccs7extra,0);
 	  $configdmr2ysf['DMR Network']['Id'] = substr($newPostDmrId,0,7);
 	  $configdmr2nxdn['DMR Network']['Id'] = substr($newPostDmrId,0,7);
 	}
@@ -1793,8 +1798,8 @@ if ($_SERVER["PHP_SELF"] == "/admin/configure.php") {
 	}
 
 	// Set the Hostname
-	if (empty($_POST['confHostame']) != TRUE ) {
-	  $newHostnameLower = strtolower(preg_replace('/[^A-Za-z0-9\-]/', '', $_POST['confHostame']));
+	if (empty($_POST['confHostname']) != TRUE ) {
+	  $newHostnameLower = strtolower(preg_replace('/[^A-Za-z0-9\-]/', '', $_POST['confHostname']));
 	  $currHostname = exec('cat /etc/hostname');
 	  $rollHostname = 'sudo sed -i "s/'.$currHostname.'/'.$newHostnameLower.'/" /etc/hostname';
 	  $rollHosts = 'sudo sed -i "s/'.$currHostname.'/'.$newHostnameLower.'/" /etc/hosts';
@@ -2483,7 +2488,38 @@ if ($_SERVER["PHP_SELF"] == "/admin/configure.php") {
                         exec('sudo chown root:root $modemConfigFileMMDVMHost');			// Set the owner
                     }
 		}
+    }
+
+	// Set the Hotspot ID
+	if (strlen($_POST['hotspotId'])) {
+        $hotspotId = $_POST['hotspotId'];
+        $hotspotId = ((((intval($hotspotId) >= 0) && (intval($hotspotId <= 9))) || (intval($hotspotId) == -1)) ? $hotspotId : '-1');
+	  
+        if (!$handleHotspotIdConfig = fopen('/tmp/cyJpZ8TDxkV9tJwQ.tmp', 'w')) {
+            return false;
         }
+
+        if (!is_writable('/tmp/cyJpZ8TDxkV9tJwQ.tmp')) {
+            echo "<br />\n";
+            echo "<table>\n";
+            echo "<tr><th>ERROR</th></tr>\n";
+            echo "<tr><td>Unable to write configuration file(s)...</td><tr>\n";
+            echo "<tr><td>Please wait a few seconds and retry...</td></tr>\n";
+            echo "</table>\n";
+            unset($_POST);
+            echo '<script type="text/javascript">setTimeout(function() { window.location=window.location;},5000);</script>';
+            die();
+        }
+        else {
+            $success = fwrite($handleHotspotIdConfig, $hotspotId.PHP_EOL);
+            fclose($handleHotspotIdConfig);
+            if (intval(exec('cat /tmp/cyJpZ8TDxkV9tJwQ.tmp | wc -l')) > 0 ) {
+                exec('sudo mv /tmp/cyJpZ8TDxkV9tJwQ.tmp /etc/hotspot_id');		// Move the file back
+                exec('sudo chmod 644 /etc/hotspot_id');				// Set the correct runtime permissions
+                exec('sudo chown root:root /etc/hotspot_id');			// Set the owner
+            }
+        }
+    }
 
 	// Start the DV Services
 	system('sudo systemctl daemon-reload > /dev/null 2>/dev/null &');			// Restart Systemd to account for any service changes
@@ -2777,9 +2813,14 @@ else:
     <th width="200"><a class="tooltip" href="#"><?php echo $lang['setting'];?><span><b>Setting</b></span></a></th>
     <th colspan="2"><a class="tooltip" href="#"><?php echo $lang['value'];?><span><b>Value</b>The current value from the<br />configuration files</span></a></th>
     </tr>
+    <?php if (file_exists('/etc/dstar-radio.mmdvmhost') && ($configmmdvm['DMR']['Enable'] == 1) && ($configmmdvm['DMR Network']['Address'] == '127.0.0.1') && ($configmmdvm['DMR Network']['Port'] == '62031')) { ?>
+    <tr>
+    <td align="left"><a class="tooltip2" href="#"><?php echo $lang['hotspot_id'];?>:<span><b>Hotspot ID</b>Enter your Hotspot ID (0 to 9, -1 to disable)</span></a></td>
+    <td align="left" colspan="2"><input type="text" name="hotspotId" size="13" maxlength="2" value="<?php if (file_exists('/etc/hotspot_id')) { echo exec('cat /etc/hotspot_id'); } else { echo "-1"; } ?>" /></td>
+    </tr><?php } ?>
     <tr>
     <td align="left"><a class="tooltip2" href="#">Hostname:<span><b>System Hostname</b>This is the system hostname, used for access to the dashboard etc.</span></a></td>
-    <td align="left" colspan="2"><input type="text" name="confHostame" size="13" maxlength="15" value="<?php echo exec('cat /etc/hostname'); ?>" />Do not add suffixes such as .local</td>
+    <td align="left" colspan="2"><input type="text" name="confHostname" size="13" maxlength="15" value="<?php echo exec('cat /etc/hostname'); ?>" />Do not add suffixes such as .local</td>
     </tr>
     <tr>
     <td align="left"><a class="tooltip2" href="#"><?php echo $lang['node_call'];?>:<span><b>Gateway Callsign</b>This is your licenced callsign for use on this gateway, do not append the "G"</span></a></td>
@@ -2795,7 +2836,7 @@ else:
       <td align="left"><a class="tooltip2" href="#">NXDN ID:<span><b>NXDN ID</b>Enter your NXDN ID here</span></a></td>
       <td align="left" colspan="2"><input type="text" name="nxdnId" size="13" maxlength="5" value="<?php if (isset($configmmdvm['NXDN']['Id'])) { echo $configmmdvm['NXDN']['Id']; } ?>" /></td>
     </tr><?php } ?>
-<?php if ($configmmdvm['Info']['TXFrequency'] === $configmmdvm['Info']['RXFrequency']) {
+    <?php if ($configmmdvm['Info']['TXFrequency'] === $configmmdvm['Info']['RXFrequency']) {
 	echo "    <tr>\n";
 	echo "    <td align=\"left\"><a class=\"tooltip2\" href=\"#\">".$lang['radio_freq'].":<span><b>Radio Frequency</b>This is the Frequency your<br />Pi-Star is on</span></a></td>\n";
 	echo "    <td align=\"left\" colspan=\"2\"><input type=\"text\" id=\"confFREQ\" onkeyup=\"checkFrequency(); return false;\" name=\"confFREQ\" size=\"13\" maxlength=\"12\" value=\"".number_format($configmmdvm['Info']['RXFrequency'], 0, '.', '.')."\" />MHz</td>\n";
@@ -2981,8 +3022,8 @@ else:
     <tr>
     <td align="left"><a class="tooltip2" href="#"><?php echo $lang['bm_network'];?>:<span><b>BrandMeister Dashboards</b>Direct links to your BrandMeister Dashboards</span></a></td>
     <td>
-      <a href="https://brandmeister.network/?page=hotspot&amp;id=<?php echo $configmmdvm['General']['Id']; ?>" target="_new" style="color: #000;">Repeater Information</a> |
-      <a href="https://brandmeister.network/?page=hotspot-edit&amp;id=<?php echo $configmmdvm['General']['Id']; ?>" target="_new" style="color: #000;">Edit Repeater (BrandMeister Selfcare)</a>
+      <a href="https://brandmeister.network/?page=hotspot&amp;id=<?php $ccs7extra=''; if (file_exists('/etc/hotspot_id') && ($configmmdvm['DMR Network']['Address'] == '127.0.0.1') && ($configmmdvm['DMR Network']['Port'] == '62031')) { $ccs7extra=exec('cat /etc/hotspot_id'); }; if ($ccs7extra == '-1') { $ccs7extra = ''; }; echo $configmmdvm['General']['Id'].$ccs7extra; ?>" target="_new" style="color: #000;">Repeater Information</a> |
+      <a href="https://brandmeister.network/?page=hotspot-edit&amp;id=<?php $ccs7extra=''; if (file_exists('/etc/hotspot_id') && ($configmmdvm['DMR Network']['Address'] == '127.0.0.1') && ($configmmdvm['DMR Network']['Port'] == '62031')) { $ccs7extra=exec('cat /etc/hotspot_id'); }; if ($ccs7extra == '-1') { $ccs7extra = ''; }; echo $configmmdvm['General']['Id'].$ccs7extra; ?>" target="_new" style="color: #000;">Edit Repeater (BrandMeister Selfcare)</a>
     </td>
     </tr>
     <tr>

--- a/lang/catalan_es.php
+++ b/lang/catalan_es.php
@@ -56,6 +56,7 @@ $lang = array (
   // Config Page - General Configuration
   "node_call"                   =>  "Indicatiu del Node",
   "dmr_id"                      =>  "CCS7/DMR ID",
+  "hotspot_id"                  =>  "Hotspot ID",
   "radio_freq"                  =>  "Freqüència RX/TX",
   "lattitude"                   =>  "Latitut",
   "longitude"                   =>  "Longitut",

--- a/lang/chinese_cn.php
+++ b/lang/chinese_cn.php
@@ -55,6 +55,7 @@ $lang = array (
   // Config Page - General Configuration
   "node_call"                   =>  "节点呼号",
   "dmr_id"                      =>  "CCS7/DMR ID",
+  "hotspot_id"                  =>  "Hotspot ID",
   "radio_freq"                  =>  "电台频率",
   "lattitude"                   =>  "纬度",
   "longitude"                   =>  "经度",

--- a/lang/chinese_hk.php
+++ b/lang/chinese_hk.php
@@ -55,6 +55,7 @@ $lang = array (
   // Config Page - General Configuration
   "node_call"                   =>  "節點呼號",
   "dmr_id"                      =>  "CCS7/DMR ID",
+  "hotspot_id"                  =>  "Hotspot ID",
   "radio_freq"                  =>  "電臺頻率",
   "lattitude"                   =>  "緯度",
   "longitude"                   =>  "經度",

--- a/lang/chinese_tw.php
+++ b/lang/chinese_tw.php
@@ -53,6 +53,7 @@ $lang = array (
   // Config Page - General Configuration
   "node_call"                   =>  "節點呼號",
   "dmr_id"                      =>  "CCS7/DMR ID",
+  "hotspot_id"                  =>  "Hotspot ID",
   "radio_freq"                  =>  "電台頻率",
   "lattitude"                   =>  "緯度",
   "longitude"                   =>  "經度",

--- a/lang/dutch_nl.php
+++ b/lang/dutch_nl.php
@@ -54,6 +54,7 @@ $lang = array (
   // Config Page - General Configuration
   "node_call"                   =>  "Node roepletters",
   "dmr_id"                      =>  "CCS7/DMR ID",
+  "hotspot_id"                  =>  "Hotspot ID",
   "radio_freq"                  =>  "Radio frequentie",
   "lattitude"                   =>  "Breedtegraad",
   "longitude"                   =>  "Lengtegraad",

--- a/lang/english_uk.php
+++ b/lang/english_uk.php
@@ -55,6 +55,7 @@ $lang = array (
   // Config Page - General Configuration
   "node_call"                   =>  "Node Callsign",
   "dmr_id"                      =>  "CCS7/DMR ID",
+  "hotspot_id"                  =>  "Hotspot ID",
   "radio_freq"                  =>  "Radio Frequency",
   "lattitude"                   =>  "Latitude",
   "longitude"                   =>  "Longitude",

--- a/lang/english_us.php
+++ b/lang/english_us.php
@@ -55,6 +55,7 @@ $lang = array (
   // Config Page - General Configuration
   "node_call"                   =>  "Node Callsign",
   "dmr_id"                      =>  "CCS7/DMR ID",
+  "hotspot_id"                  =>  "Hotspot ID",
   "radio_freq"                  =>  "Radio Frequency",
   "lattitude"                   =>  "Latitude",
   "longitude"                   =>  "Longitude",

--- a/lang/french_fr.php
+++ b/lang/french_fr.php
@@ -55,6 +55,7 @@ $lang = array (
   // Config Page - General Configuration
   "node_call"                   =>  "Indicatif du Node",
   "dmr_id"                      =>  "Id CCS7/DMR",
+  "hotspot_id"                  =>  "Id Hotspot",
   "radio_freq"                  =>  "Fr&eacute;quence radio",
   "lattitude"                   =>  "Latitude",
   "longitude"                   =>  "Longitude",

--- a/lang/german_de.php
+++ b/lang/german_de.php
@@ -55,6 +55,7 @@ $lang = array (
   // Config Page - General Configuration
   "node_call"                   =>  "Node Rufzeichen",
   "dmr_id"                      =>  "CCS7/DMR ID",
+  "hotspot_id"                  =>  "Hotspot ID",
   "radio_freq"                  =>  "Radio Frequenz",
   "lattitude"                   =>  "Breitengrad",
   "longitude"                   =>  "L&auml;ngengrad",

--- a/lang/greek_gr.php
+++ b/lang/greek_gr.php
@@ -55,6 +55,7 @@ $lang = array (
   // Config Page - General Configuration
   "node_call"                   =>  "Διακριτικό Κόμβου",
   "dmr_id"                      =>  "Ταυτότητα CCS7/DMR",
+  "hotspot_id"                  =>  "Hotspot ID",
   "radio_freq"                  =>  "Συχνότητα",
   "lattitude"                   =>  "Γεωγραφικό Πλάτος",
   "longitude"                   =>  "Γεωγραφικό Μήκος",

--- a/lang/italian_it.php
+++ b/lang/italian_it.php
@@ -55,6 +55,7 @@ $lang = array (
   // Config Page - General Configuration
   "node_call"                   =>  "Nominativo",
   "dmr_id"                      =>  "CCS7/DMR ID",
+  "hotspot_id"                  =>  "Hotspot ID",
   "radio_freq"                  =>  "Frequenza Radio",
   "lattitude"                   =>  "Latitudine",
   "longitude"                   =>  "Longitudine",

--- a/lang/japanese_jp.php
+++ b/lang/japanese_jp.php
@@ -55,6 +55,7 @@ $lang = array (
   // Config Page - General Configuration
   "node_call"                   =>  "ノード コールサイン",
   "dmr_id"                      =>  "CCS7/DMR ID",
+  "hotspot_id"                  =>  "Hotspot ID",
   "radio_freq"                  =>  "周波数",
   "lattitude"                   =>  "緯度",
   "longitude"                   =>  "経度",

--- a/lang/norwegian_no.php
+++ b/lang/norwegian_no.php
@@ -55,6 +55,7 @@ $lang = array (
   // Config Page - General Configuration
   "node_call"                   =>  "Node Kallesignal",
   "dmr_id"                      =>  "CCS7/DMR ID",
+  "hotspot_id"                  =>  "Hotspot ID",
   "radio_freq"                  =>  "Radio Frekvens",
   "lattitude"                   =>  "Breddegrad",
   "longitude"                   =>  "lengdegrad",

--- a/lang/portuguese_br.php
+++ b/lang/portuguese_br.php
@@ -55,6 +55,7 @@ $lang = array (
   // Config Page - General Configuration
   "node_call"                   =>  "Indicativo do Node",
   "dmr_id"                      =>  "CCS7/DMR ID",
+  "hotspot_id"                  =>  "Hotspot ID",
   "radio_freq"                  =>  "Frequencia do Rádio",
   "lattitude"                   =>  "Latitude",
   "longitude"                   =>  "Longitude",

--- a/lang/portuguese_pt.php
+++ b/lang/portuguese_pt.php
@@ -55,6 +55,7 @@ $lang = array (
   // Config Page - General Configuration
   "node_call"                   =>  "Indicativo do Nó",
   "dmr_id"                      =>  "CCS7/DMR ID",
+  "hotspot_id"                  =>  "Hotspot ID",
   "radio_freq"                  =>  "Frequência do Rádio",
   "lattitude"                   =>  "Latitude",
   "longitude"                   =>  "Longitude",

--- a/lang/romanian_ro.php
+++ b/lang/romanian_ro.php
@@ -55,6 +55,7 @@ $lang = array (
   // Config Page - General Configuration
   "node_call"                   =>  "Indicativ Node",
   "dmr_id"                      =>  "CCS7/ID DMR",
+  "hotspot_id"                  =>  "Hotspot ID",
   "radio_freq"                  =>  "Frecventa Radio",
   "lattitude"                   =>  "Latitudine",
   "longitude"                   =>  "Longitudine",

--- a/lang/spanish_es.php
+++ b/lang/spanish_es.php
@@ -55,6 +55,7 @@ $lang = array (
   // Config Page - General Configuration
   "node_call"                   =>  "Nodo indicativo de llamada",
   "dmr_id"                      =>  "CCS7/DMR ID",
+  "hotspot_id"                  =>  "Hotspot ID",
   "radio_freq"                  =>  "Frecuencia RX/TX",
   "lattitude"                   =>  "Latitud",
   "longitude"                   =>  "Longitud",

--- a/lang/spanish_mx.php
+++ b/lang/spanish_mx.php
@@ -55,6 +55,7 @@ $lang = array (
   // Config Page - General Configuration
   "node_call"                   =>  "Nodo signo de llamada",
   "dmr_id"                      =>  "CCS7/DMR ID",
+  "hotspot_id"                  =>  "Hotspot ID",
   "radio_freq"                  =>  "Radio Frecuencia",
   "lattitude"                   =>  "Latitud",
   "longitude"                   =>  "Longitud",

--- a/lang/thai_th.php
+++ b/lang/thai_th.php
@@ -55,6 +55,7 @@ $lang = array (
   // Config Page - General Configuration
   "node_call"                   =>  "นามเรียกขานของสถานี",
   "dmr_id"                      =>  "CCS7/DMR ID",
+  "hotspot_id"                  =>  "Hotspot ID",
   "radio_freq"                  =>  "ความถี่ที่ใช้งาน",
   "lattitude"                   =>  "ละติจูด",
   "longitude"                   =>  "ลองจิจูด",

--- a/lang/turkish_tr.php
+++ b/lang/turkish_tr.php
@@ -55,6 +55,7 @@ $lang = array (
   // Config Page - General Configuration
   "node_call"                   =>  "Çağrı İşaretiniz",
   "dmr_id"                      =>  "CCS7/DMR No",
+  "hotspot_id"                  =>  "Hotspot ID",
   "radio_freq"                  =>  "Radyo Frekansı",
   "lattitude"                   =>  "Enlem",
   "longitude"                   =>  "Boylam",

--- a/mmdvmhost/bm_links.php
+++ b/mmdvmhost/bm_links.php
@@ -19,7 +19,7 @@ if ( $testMMDVModeDMR == 1 ) {
 
   // Get the current DMR Master from the config
   $dmrMasterHost = getConfigItem("DMR Network", "Address", $mmdvmconfigs);
-  if ( $dmrMasterHost == '127.0.0.1' ) { $dmrMasterHost = $configdmrgateway['DMR Network 1']['Address']; }
+  if ( $dmrMasterHost == '127.0.0.1' ) { $dmrMasterHost = $configdmrgateway['DMR Network 1']['Address']; $dmrGWID = $configdmrgateway['DMR Network 1']['Id']; }
 
   // Store the DMR Master IP, we will need this for the JSON lookup
   $dmrMasterHostIP = $dmrMasterHost;
@@ -36,7 +36,7 @@ if ( $testMMDVModeDMR == 1 ) {
 
   if (substr($dmrMasterHost, 0, 2) == "BM") {
   // DMR ID, we will need this for the JSON lookup
-  $dmrID = getConfigItem("General", "Id", $mmdvmconfigs);
+  $dmrID = ( ! empty($dmrGWID) ? $dmrGWID : getConfigItem("General", "Id", $mmdvmconfigs));
 
   // Use BM API to get information about current TGs
   $jsonContext = stream_context_create(array('http'=>array('timeout' => 2) )); // Add Timout

--- a/mmdvmhost/bm_manager.php
+++ b/mmdvmhost/bm_manager.php
@@ -23,7 +23,7 @@ if ( $testMMDVModeDMR == 1 ) {
 
   // Get the current DMR Master from the config
   $dmrMasterHost = getConfigItem("DMR Network", "Address", $mmdvmconfigs);
-  if ( $dmrMasterHost == '127.0.0.1' ) { $dmrMasterHost = $configdmrgateway['DMR Network 1']['Address']; }
+  if ( $dmrMasterHost == '127.0.0.1' ) { $dmrMasterHost = $configdmrgateway['DMR Network 1']['Address']; $dmrGWID = $configdmrgateway['DMR Network 1']['Id']; }
 
   // Store the DMR Master IP, we will need this for the JSON lookup
   $dmrMasterHostIP = $dmrMasterHost;
@@ -39,8 +39,7 @@ if ( $testMMDVModeDMR == 1 ) {
   }
     if (substr($dmrMasterHost, 0, 2) == "BM") {
     // OK this is Brandmeister, get some config and output the HTML
-    $dmrID = getConfigItem("General", "Id", $mmdvmconfigs);
-    
+    $dmrID = ( ! empty($dmrGWID) ? $dmrGWID : getConfigItem("General", "Id", $mmdvmconfigs));
 
   // If there is a BM API Key
   $bmAPIurl = 'https://api.brandmeister.network/v1.0/repeater/';


### PR DESCRIPTION
   - Adding an extra digit to the CCS7 permits to have more than one hotspot connected to BM or DMR+. DMR+ allows ten hotspots (0 to 9), BM allows hundred (00 to 99).   - Since BM and DMR+ share the config, it's limited to 10 hotspots.
   - Hotspot ID could be changed in General Configuration panel, value could be 0..9 or -1 (default) to don't use the hotspot ID feature. Value is stored in /etc/hotspot_id, and it's part of the backup/restore.
   - Hotspot ID parameter in General Configuration will only appears when DMRGateway is selected as the DMR Master.
   - URLs related to BM in DMR Configuration also take care of hotspot ID.
   - CCS7 + Hotspot ID are also used in bm link and bm manager.

If /etc/hotspot_id is missing, the code consider hotspot ID as -1 (disabled).

Lang files: required entry has been added in all files, but translated in US, UK and FR only.