### PR TITLE
POCSAG: add HAMNET entry for DAPNET

### DIFF
--- a/admin/configure.php
+++ b/admin/configure.php
@@ -3718,6 +3718,7 @@ $p25Hosts = fopen("/usr/local/etc/P25Hosts.txt", "r");
 	<td style="text-align: left;"><select name="pocsagServer">
         	<option value="<?php echo $configdapnetgw['DAPNET']['Address'];?>" selected="selected"><?php echo $configdapnetgw['DAPNET']['Address'];?></option>
 		<option value="dapnet.afu.rwth-aachen.de">dapnet.afu.rwth-aachen.de</option>
+		<option value="dapnet.db0sda.ampr.org">dapnet.db0sda.ampr.org</option>
 		<option value="node1.dapnet-italia.it">node1.dapnet-italia.it</option>
 		</select></td>
       </tr>


### PR DESCRIPTION
DAPNET server in HAMNET added (dapnet.db0sda.ampr.org). For nodes which are not or not only on the internet. See also: https://hampager.de/dokuwiki/doku.php?id=dapnetoverview