### PR TITLE
POCSAG enhancements

### DIFF
--- a/admin/config_backup.php
+++ b/admin/config_backup.php
@@ -62,6 +62,9 @@ if ($_SERVER["PHP_SELF"] == "/admin/config_backup.php") {
 	  if (shell_exec('cat /etc/dhcpcd.conf | grep "static ip_address" | grep -v "#"')) {
 		  $output .= shell_exec("sudo cp /etc/dhcpcd.conf $backupDir 2>&1");
 	  }
+          if (file_exists('/etc/hotspot_id')) {
+	          $output .= shell_exec("sudo cp /etc/hotspot_id $backupDir 2>&1");
+	  }
           $output .= shell_exec("sudo cp /etc/wpa_supplicant/wpa_supplicant.conf $backupDir 2>&1");
           $output .= shell_exec("sudo cp /etc/ircddbgateway $backupDir 2>&1");
           $output .= shell_exec("sudo cp /etc/mmdvmhost $backupDir 2>&1");

--- a/admin/configure.php
+++ b/admin/configure.php
@@ -3825,7 +3825,7 @@ $p25Hosts = fopen("/usr/local/etc/P25Hosts.txt", "r");
 	<div><input type="button" value="<?php echo $lang['apply'];?>" onclick="submitform()" /><br /><br /></div>
 <?php } ?>
 
-<?php if ( $configmmdvm['POCSAG']['Enable'] == 1 ) { ?>
+<?php if ( $configmmdvm['POCSAG']['Enable'] == 1 ) { ?> <!-- RMB -->
 	<div><b><?php echo $lang['pocsag_config'];?></b></div>
     <table>
       <tr>

--- a/admin/configure.php
+++ b/admin/configure.php
@@ -3825,7 +3825,7 @@ $p25Hosts = fopen("/usr/local/etc/P25Hosts.txt", "r");
 	<div><input type="button" value="<?php echo $lang['apply'];?>" onclick="submitform()" /><br /><br /></div>
 <?php } ?>
 
-<?php if ( $configmmdvm['POCSAG']['Enable'] == 1 ) { ?> <!-- RMB -->
+<?php if ( $configmmdvm['POCSAG']['Enable'] == 1 ) { ?>
 	<div><b><?php echo $lang['pocsag_config'];?></b></div>
     <table>
       <tr>

--- a/admin/expert/edit_dapnetgateway.php
+++ b/admin/expert/edit_dapnetgateway.php
@@ -1,0 +1,127 @@
+<?php
+// Load the language support
+require_once('../config/language.php');
+//Load the Pi-Star Release file
+$pistarReleaseConfig = '/etc/pistar-release';
+$configPistarRelease = array();
+$configPistarRelease = parse_ini_file($pistarReleaseConfig, true);
+//Load the Version Info
+require_once('../config/version.php');
+?>
+  <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+  "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+  <html xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" lang="en">
+  <head>
+    <meta name="robots" content="index" />
+    <meta name="robots" content="follow" />
+    <meta name="language" content="English" />
+    <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
+    <meta name="Author" content="Andrew Taylor (MW0MWZ)" />
+    <meta name="Description" content="Pi-Star Expert Editor" />
+    <meta name="KeyWords" content="Pi-Star" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
+    <meta http-equiv="pragma" content="no-cache" />
+<link rel="shortcut icon" href="images/favicon.ico" type="image/x-icon">
+    <meta http-equiv="Expires" content="0" />
+    <title>Pi-Star - Digital Voice Dashboard - Expert Editor</title>
+    <link rel="stylesheet" type="text/css" href="../css/pistar-css.php" />
+  </head>
+  <body>
+  <div class="container">
+  <?php include './header-menu.inc'; ?>
+  <div class="contentwide">
+
+<?php
+//Do some file wrangling...
+exec('sudo cp /etc/dapnetgateway /tmp/cVKu8oJJKWqe.tmp');
+exec('sudo chown www-data:www-data /tmp/cVKu8oJJKWqe.tmp');
+exec('sudo chmod 664 /tmp/cVKu8oJJKWqe.tmp');
+
+//ini file to open
+$filepath = '/tmp/cVKu8oJJKWqe.tmp';
+
+//after the form submit
+if($_POST) {
+	$data = $_POST;
+	//update ini file, call function
+	update_ini_file($data, $filepath);
+}
+
+//this is the function going to update your ini file
+	function update_ini_file($data, $filepath) {
+		$content = "";
+
+		//parse the ini file to get the sections
+		//parse the ini file using default parse_ini_file() PHP function
+		$parsed_ini = parse_ini_file($filepath, true);
+
+		foreach($data as $section=>$values) {
+			// UnBreak special cases
+			$section = str_replace("_", " ", $section);
+			$content .= "[".$section."]\n";
+			//append the values
+			foreach($values as $key=>$value) {
+				if (($section == "General" || $section == "Log") && $key == "DAPNET" && $value) {
+					$value = str_replace('"', "", $value);
+					$content .= $key."=\"".$value."\"\n";
+				}
+				else {
+					$content .= $key."=".$value."\n";
+				}
+			}
+			$content .= "\n";
+		}
+
+		//write it into file
+		if (!$handle = fopen($filepath, 'w')) {
+			return false;
+		}
+
+		$success = fwrite($handle, $content);
+		fclose($handle);
+
+		// Updates complete - copy the working file back to the proper location
+		exec('sudo mount -o remount,rw /');				                // Make rootfs writable
+		exec('sudo cp /tmp/cVKu8oJJKWqe.tmp /etc/dapnetgateway');	    // Move the file back
+		exec('sudo chmod 644 /etc/dapnetgateway');				        // Set the correct runtime permissions
+		exec('sudo chown root:root /etc/dapnetgateway');			    // Set the owner
+		exec('sudo mount -o remount,ro /');				                // Make rootfs read-only
+
+		// Reload the affected daemon
+		exec('sudo systemctl restart dapnetgateway.service');		    // Reload the daemon
+		return $success;
+	}
+
+//parse the ini file using default parse_ini_file() PHP function
+$parsed_ini = parse_ini_file($filepath, true);
+
+echo '<form action="" method="post">'."\n";
+	foreach($parsed_ini as $section=>$values) {
+		// keep the section as hidden text so we can update once the form submitted
+		echo "<input type=\"hidden\" value=\"$section\" name=\"$section\" />\n";
+		echo "<table>\n";
+		echo "<tr><th colspan=\"2\">$section</th></tr>\n";
+		// print all other values as input fields, so can edit. 
+		// note the name='' attribute it has both section and key
+		foreach($values as $key=>$value) {
+			echo "<tr><td align=\"right\" width=\"30%\">$key</td><td align=\"left\"><input type=\"text\" name=\"{$section}[$key]\" value=\"$value\" /></td></tr>\n";
+		}
+		echo "</table>\n";
+		echo '<input type="submit" value="'.$lang['apply'].'" />'."\n";
+		echo "<br />\n";
+	}
+echo "</form>";
+?>
+</div>
+
+<div class="footer">
+Pi-Star / Pi-Star Dashboard, &copy; Andy Taylor (MW0MWZ) 2014-<?php echo date("Y"); ?>.<br />
+ircDDBGateway Dashboard by Hans-J. Barthen (DL5DI),<br />
+MMDVMDash developed by Kim Huebel (DG9VH), <br />
+Need help? Click <a style="color: #ffffff;" href="https://www.facebook.com/groups/pistarusergroup/" target="_new">here for the Support Group</a><br />
+Get your copy of Pi-Star from <a style="color: #ffffff;" href="http://www.pistar.uk/downloads/" target="_new">here</a>.<br />
+</div>
+
+</div>
+</body>
+</html>

--- a/admin/expert/fulledit_dapnetgateway.php
+++ b/admin/expert/fulledit_dapnetgateway.php
@@ -32,45 +32,38 @@ require_once('../config/version.php');
   <div class="contentwide">
 
 <?php
-// Make the bare config if we dont have one
-if (file_exists('/etc/dapnetapi.key')) {
-	exec('sudo cp /etc/dapnetapi.key /tmp/jsADGHwf9sj294.tmp');
-	exec('sudo chown www-data:www-data /tmp/jsADGHwf9sj294.tmp');
-} else {
-	exec('sudo touch /tmp/jsADGHwf9sj294.tmp');
-	exec('sudo chown www-data:www-data /tmp/jsADGHwf9sj294.tmp');
-	exec('echo "[DAPNETAPI]" > /tmp/jsADGHwf9sj294.tmp');
-	exec('echo "USER=" >> /tmp/jsADGHwf9sj294.tmp');
-	exec('echo "PASS=" >> /tmp/jsADGHwf9sj294.tmp');
-	exec('echo "TRXAREA=" >> /tmp/jsADGHwf9sj294.tmp');
-}
-
-//Do some file wrangling...
-exec('sudo chmod 664 /tmp/jsADGHwf9sj294.tmp');
-
-//ini file to open
-$filepath = '/tmp/jsADGHwf9sj294.tmp';
-
 if(isset($_POST['data'])) {
+        // File Wrangling
+        exec('sudo cp /etc/dapnetgateway /tmp/cVKu8oJJKWqe.tmp');
+        exec('sudo chown www-data:www-data /tmp/cVKu8oJJKWqe.tmp');
+        exec('sudo chmod 664 /tmp/cVKu8oJJKWqe.tmp');
+
         // Open the file and write the data
+        $filepath = '/tmp/cVKu8oJJKWqe.tmp';
         $fh = fopen($filepath, 'w');
         fwrite($fh, $_POST['data']);
         fclose($fh);
         exec('sudo mount -o remount,rw /');
-        exec('sudo cp /tmp/jsADGHwf9sj294.tmp /etc/dapnetapi.key');
-        exec('sudo chmod 644 /etc/dapnetapi.key');
-        exec('sudo chown root:root /etc/dapnetapi.key');
+        exec('sudo cp /tmp/cVKu8oJJKWqe.tmp /etc/dapnetgateway');
+        exec('sudo chmod 644 /etc/dapnetgateway');
+        exec('sudo chown root:root /etc/dapnetgateway');
         exec('sudo mount -o remount,ro /');
   
         // Reload the affected daemon
-		exec('sudo systemctl restart dapnetgateway.service'); // Reload the daemon
+		    exec('sudo systemctl restart dapnetgateway.service');		    // Reload the daemon
 
         // Re-open the file and read it
         $fh = fopen($filepath, 'r');
         $theData = fread($fh, filesize($filepath));
 
 } else {
+        // File Wrangling
+        exec('sudo cp /etc/dapnetgateway /tmp/cVKu8oJJKWqe.tmp');
+        exec('sudo chown www-data:www-data /tmp/cVKu8oJJKWqe.tmp');
+        exec('sudo chmod 664 /tmp/cVKu8oJJKWqe.tmp');
+
         // Open the file and read it
+        $filepath = '/tmp/cVKu8oJJKWqe.tmp';
         $fh = fopen($filepath, 'r');
         $theData = fread($fh, filesize($filepath));
 }
@@ -78,10 +71,9 @@ fclose($fh);
 
 ?>
 <form name="test" method="post" action="">
-    <textarea name="data" cols="80" rows="45"><?php echo $theData; ?></textarea><br />
+<textarea name="data" cols="80" rows="45"><?php echo $theData; ?></textarea><br />
 <input type="submit" name="submit" value="<?php echo $lang['apply']; ?>" />
-    </form>
-
+</form>
 </div>
 
 <div class="footer">

--- a/admin/expert/header-menu.inc
+++ b/admin/expert/header-menu.inc
@@ -12,19 +12,20 @@
   <p style="padding-right: 5px; text-align: right; color: #ffffff;">
     <b>Quick Edit:</b>
     <a href="edit_dstarrepeater.php" style="color: #ffffff;">DStarRepeater</a> |
-    <a href="edit_ircddbgateway.php" style="color: #ffffff;">ircDDBGateway</a> |
+    <a href="edit_ircddbgateway.php" style="color: #ffffff;">ircDDB GW</a> |
     <a href="edit_timeserver.php" style="color: #ffffff;">TimeServer</a> |
     <a href="edit_mmdvmhost.php" style="color: #ffffff;">MMDVMHost</a> |
     <a href="edit_dmrgateway.php" style="color: #ffffff;">DMR GW</a> |
     <a href="edit_ysfgateway.php" style="color: #ffffff;">YSF GW</a> |
     <a href="edit_p25gateway.php" style="color: #ffffff;">P25 GW</a> |
-    <a href="edit_nxdngateway.php" style="color: #ffffff;">NXDN GW</a><br />
+    <a href="edit_nxdngateway.php" style="color: #ffffff;">NXDN GW</a> |
+    DAPNet [<a href="edit_dapnetgateway.php" style="color: #ffffff;">GW</a>|<a href="edit_dapnetapi.php" style="color: #ffffff;">API</a>]<br /> 
     <b>Full Edit:</b>
     <a href="fulledit_dmrgateway.php" style="color: #ffffff;">DMR GW</a> |
     <a href="fulledit_pistar-remote.php" style="color: #ffffff;">PiStar-Remote</a> |
     <a href="fulledit_wpaconfig.php" style="color: #ffffff;">WiFi</a> |
     <a href="fulledit_bmapikey.php" style="color: #ffffff;">BM API</a> |
-    <a href="fulledit_dapnetapi.php" style="color: #ffffff;">DAPNET API</a> |
+     DAPNet [<a href="fulledit_dapnetgateway.php" style="color: #ffffff;">GW</a>|<a href="fulledit_dapnetapi.php" style="color: #ffffff;">API</a>] |
     <a href="fulledit_cron.php" style="color: #ffffff;">System Cron</a> |
     <a href="fulledit_rssidat.php" style="color: #ffffff;">RSSI Dat</a>
     &emsp;<b>Tools:</b>

--- a/index.php
+++ b/index.php
@@ -183,6 +183,13 @@ if (file_exists('/etc/dstar-radio.mmdvmhost')) {
 	// If POCSAG is enabled, show the information pannel
 	$testMMDVModePOCSAG = getConfigItem("POCSAG Network", "Enable", $mmdvmconfigfile);
 	if ( $testMMDVModePOCSAG == 1 ) {
+		if ($_SERVER["PHP_SELF"] == "/admin/index.php") {  // Admin Only Options
+			echo "<br />\n";
+            echo '<div id="dapnetMsgr">'."\n";
+            include 'mmdvmhost/dapnet_messenger.php';
+            echo '</div>'."\n";
+        }
+
 		echo '<script type="text/javascript">'."\n";
 		echo 'function reloadPages(){'."\n";
 		echo '  $("#Pages").load("/mmdvmhost/pages.php",function(){ setTimeout(reloadPages,5000) });'."\n";

--- a/lang/catalan_es.php
+++ b/lang/catalan_es.php
@@ -56,6 +56,7 @@ $lang = array (
   // Config Page - General Configuration
   "node_call"                   =>  "Indicatiu del Node",
   "dmr_id"                      =>  "CCS7/DMR ID",
+  "hotspot_id"                  =>  "Hotspot ID",
   "radio_freq"                  =>  "Freqüència RX/TX",
   "lattitude"                   =>  "Latitut",
   "longitude"                   =>  "Longitut",

--- a/lang/chinese_cn.php
+++ b/lang/chinese_cn.php
@@ -55,6 +55,7 @@ $lang = array (
   // Config Page - General Configuration
   "node_call"                   =>  "节点呼号",
   "dmr_id"                      =>  "CCS7/DMR ID",
+  "hotspot_id"                  =>  "Hotspot ID",
   "radio_freq"                  =>  "电台频率",
   "lattitude"                   =>  "纬度",
   "longitude"                   =>  "经度",

--- a/lang/chinese_hk.php
+++ b/lang/chinese_hk.php
@@ -55,6 +55,7 @@ $lang = array (
   // Config Page - General Configuration
   "node_call"                   =>  "節點呼號",
   "dmr_id"                      =>  "CCS7/DMR ID",
+  "hotspot_id"                  =>  "Hotspot ID",
   "radio_freq"                  =>  "電臺頻率",
   "lattitude"                   =>  "緯度",
   "longitude"                   =>  "經度",

--- a/lang/chinese_tw.php
+++ b/lang/chinese_tw.php
@@ -53,6 +53,7 @@ $lang = array (
   // Config Page - General Configuration
   "node_call"                   =>  "節點呼號",
   "dmr_id"                      =>  "CCS7/DMR ID",
+  "hotspot_id"                  =>  "Hotspot ID",
   "radio_freq"                  =>  "電台頻率",
   "lattitude"                   =>  "緯度",
   "longitude"                   =>  "經度",

--- a/lang/dutch_nl.php
+++ b/lang/dutch_nl.php
@@ -54,6 +54,7 @@ $lang = array (
   // Config Page - General Configuration
   "node_call"                   =>  "Node roepletters",
   "dmr_id"                      =>  "CCS7/DMR ID",
+  "hotspot_id"                  =>  "Hotspot ID",
   "radio_freq"                  =>  "Radio frequentie",
   "lattitude"                   =>  "Breedtegraad",
   "longitude"                   =>  "Lengtegraad",

--- a/lang/english_uk.php
+++ b/lang/english_uk.php
@@ -55,6 +55,7 @@ $lang = array (
   // Config Page - General Configuration
   "node_call"                   =>  "Node Callsign",
   "dmr_id"                      =>  "CCS7/DMR ID",
+  "hotspot_id"                  =>  "Hotspot ID",
   "radio_freq"                  =>  "Radio Frequency",
   "lattitude"                   =>  "Latitude",
   "longitude"                   =>  "Longitude",

--- a/lang/english_us.php
+++ b/lang/english_us.php
@@ -55,6 +55,7 @@ $lang = array (
   // Config Page - General Configuration
   "node_call"                   =>  "Node Callsign",
   "dmr_id"                      =>  "CCS7/DMR ID",
+  "hotspot_id"                  =>  "Hotspot ID",
   "radio_freq"                  =>  "Radio Frequency",
   "lattitude"                   =>  "Latitude",
   "longitude"                   =>  "Longitude",

--- a/lang/french_fr.php
+++ b/lang/french_fr.php
@@ -55,6 +55,7 @@ $lang = array (
   // Config Page - General Configuration
   "node_call"                   =>  "Indicatif du Node",
   "dmr_id"                      =>  "Id CCS7/DMR",
+  "hotspot_id"                  =>  "Id Hotspot",
   "radio_freq"                  =>  "Fr&eacute;quence radio",
   "lattitude"                   =>  "Latitude",
   "longitude"                   =>  "Longitude",

--- a/lang/german_de.php
+++ b/lang/german_de.php
@@ -55,6 +55,7 @@ $lang = array (
   // Config Page - General Configuration
   "node_call"                   =>  "Node Rufzeichen",
   "dmr_id"                      =>  "CCS7/DMR ID",
+  "hotspot_id"                  =>  "Hotspot ID",
   "radio_freq"                  =>  "Radio Frequenz",
   "lattitude"                   =>  "Breitengrad",
   "longitude"                   =>  "L&auml;ngengrad",

--- a/lang/greek_gr.php
+++ b/lang/greek_gr.php
@@ -55,6 +55,7 @@ $lang = array (
   // Config Page - General Configuration
   "node_call"                   =>  "Διακριτικό Κόμβου",
   "dmr_id"                      =>  "Ταυτότητα CCS7/DMR",
+  "hotspot_id"                  =>  "Hotspot ID",
   "radio_freq"                  =>  "Συχνότητα",
   "lattitude"                   =>  "Γεωγραφικό Πλάτος",
   "longitude"                   =>  "Γεωγραφικό Μήκος",

--- a/lang/italian_it.php
+++ b/lang/italian_it.php
@@ -55,6 +55,7 @@ $lang = array (
   // Config Page - General Configuration
   "node_call"                   =>  "Nominativo",
   "dmr_id"                      =>  "CCS7/DMR ID",
+  "hotspot_id"                  =>  "Hotspot ID",
   "radio_freq"                  =>  "Frequenza Radio",
   "lattitude"                   =>  "Latitudine",
   "longitude"                   =>  "Longitudine",

--- a/lang/japanese_jp.php
+++ b/lang/japanese_jp.php
@@ -55,6 +55,7 @@ $lang = array (
   // Config Page - General Configuration
   "node_call"                   =>  "ノード コールサイン",
   "dmr_id"                      =>  "CCS7/DMR ID",
+  "hotspot_id"                  =>  "Hotspot ID",
   "radio_freq"                  =>  "周波数",
   "lattitude"                   =>  "緯度",
   "longitude"                   =>  "経度",

--- a/lang/norwegian_no.php
+++ b/lang/norwegian_no.php
@@ -55,6 +55,7 @@ $lang = array (
   // Config Page - General Configuration
   "node_call"                   =>  "Node Kallesignal",
   "dmr_id"                      =>  "CCS7/DMR ID",
+  "hotspot_id"                  =>  "Hotspot ID",
   "radio_freq"                  =>  "Radio Frekvens",
   "lattitude"                   =>  "Breddegrad",
   "longitude"                   =>  "lengdegrad",

--- a/lang/portuguese_br.php
+++ b/lang/portuguese_br.php
@@ -55,6 +55,7 @@ $lang = array (
   // Config Page - General Configuration
   "node_call"                   =>  "Indicativo do Node",
   "dmr_id"                      =>  "CCS7/DMR ID",
+  "hotspot_id"                  =>  "Hotspot ID",
   "radio_freq"                  =>  "Frequencia do Rádio",
   "lattitude"                   =>  "Latitude",
   "longitude"                   =>  "Longitude",

--- a/lang/portuguese_pt.php
+++ b/lang/portuguese_pt.php
@@ -55,6 +55,7 @@ $lang = array (
   // Config Page - General Configuration
   "node_call"                   =>  "Indicativo do Nó",
   "dmr_id"                      =>  "CCS7/DMR ID",
+  "hotspot_id"                  =>  "Hotspot ID",
   "radio_freq"                  =>  "Frequência do Rádio",
   "lattitude"                   =>  "Latitude",
   "longitude"                   =>  "Longitude",

--- a/lang/romanian_ro.php
+++ b/lang/romanian_ro.php
@@ -55,6 +55,7 @@ $lang = array (
   // Config Page - General Configuration
   "node_call"                   =>  "Indicativ Node",
   "dmr_id"                      =>  "CCS7/ID DMR",
+  "hotspot_id"                  =>  "Hotspot ID",
   "radio_freq"                  =>  "Frecventa Radio",
   "lattitude"                   =>  "Latitudine",
   "longitude"                   =>  "Longitudine",

--- a/lang/spanish_es.php
+++ b/lang/spanish_es.php
@@ -55,6 +55,7 @@ $lang = array (
   // Config Page - General Configuration
   "node_call"                   =>  "Nodo indicativo de llamada",
   "dmr_id"                      =>  "CCS7/DMR ID",
+  "hotspot_id"                  =>  "Hotspot ID",
   "radio_freq"                  =>  "Frecuencia RX/TX",
   "lattitude"                   =>  "Latitud",
   "longitude"                   =>  "Longitud",

--- a/lang/spanish_mx.php
+++ b/lang/spanish_mx.php
@@ -55,6 +55,7 @@ $lang = array (
   // Config Page - General Configuration
   "node_call"                   =>  "Nodo signo de llamada",
   "dmr_id"                      =>  "CCS7/DMR ID",
+  "hotspot_id"                  =>  "Hotspot ID",
   "radio_freq"                  =>  "Radio Frecuencia",
   "lattitude"                   =>  "Latitud",
   "longitude"                   =>  "Longitud",

--- a/lang/thai_th.php
+++ b/lang/thai_th.php
@@ -55,6 +55,7 @@ $lang = array (
   // Config Page - General Configuration
   "node_call"                   =>  "นามเรียกขานของสถานี",
   "dmr_id"                      =>  "CCS7/DMR ID",
+  "hotspot_id"                  =>  "Hotspot ID",
   "radio_freq"                  =>  "ความถี่ที่ใช้งาน",
   "lattitude"                   =>  "ละติจูด",
   "longitude"                   =>  "ลองจิจูด",

--- a/lang/turkish_tr.php
+++ b/lang/turkish_tr.php
@@ -55,6 +55,7 @@ $lang = array (
   // Config Page - General Configuration
   "node_call"                   =>  "Çağrı İşaretiniz",
   "dmr_id"                      =>  "CCS7/DMR No",
+  "hotspot_id"                  =>  "Hotspot ID",
   "radio_freq"                  =>  "Radyo Frekansı",
   "lattitude"                   =>  "Enlem",
   "longitude"                   =>  "Boylam",

--- a/mmdvmhost/bm_links.php
+++ b/mmdvmhost/bm_links.php
@@ -19,7 +19,7 @@ if ( $testMMDVModeDMR == 1 ) {
 
   // Get the current DMR Master from the config
   $dmrMasterHost = getConfigItem("DMR Network", "Address", $mmdvmconfigs);
-  if ( $dmrMasterHost == '127.0.0.1' ) { $dmrMasterHost = $configdmrgateway['DMR Network 1']['Address']; }
+  if ( $dmrMasterHost == '127.0.0.1' ) { $dmrMasterHost = $configdmrgateway['DMR Network 1']['Address']; $dmrGWID = $configdmrgateway['DMR Network 1']['Id']; }
 
   // Store the DMR Master IP, we will need this for the JSON lookup
   $dmrMasterHostIP = $dmrMasterHost;
@@ -36,7 +36,7 @@ if ( $testMMDVModeDMR == 1 ) {
 
   if (substr($dmrMasterHost, 0, 2) == "BM") {
   // DMR ID, we will need this for the JSON lookup
-  $dmrID = getConfigItem("General", "Id", $mmdvmconfigs);
+  $dmrID = ( ! empty($dmrGWID) ? $dmrGWID : getConfigItem("General", "Id", $mmdvmconfigs));
 
   // Use BM API to get information about current TGs
   $jsonContext = stream_context_create(array('http'=>array('timeout' => 2) )); // Add Timout

--- a/mmdvmhost/bm_manager.php
+++ b/mmdvmhost/bm_manager.php
@@ -23,7 +23,7 @@ if ( $testMMDVModeDMR == 1 ) {
 
   // Get the current DMR Master from the config
   $dmrMasterHost = getConfigItem("DMR Network", "Address", $mmdvmconfigs);
-  if ( $dmrMasterHost == '127.0.0.1' ) { $dmrMasterHost = $configdmrgateway['DMR Network 1']['Address']; }
+  if ( $dmrMasterHost == '127.0.0.1' ) { $dmrMasterHost = $configdmrgateway['DMR Network 1']['Address']; $dmrGWID = $configdmrgateway['DMR Network 1']['Id']; }
 
   // Store the DMR Master IP, we will need this for the JSON lookup
   $dmrMasterHostIP = $dmrMasterHost;
@@ -39,8 +39,7 @@ if ( $testMMDVModeDMR == 1 ) {
   }
     if (substr($dmrMasterHost, 0, 2) == "BM") {
     // OK this is Brandmeister, get some config and output the HTML
-    $dmrID = getConfigItem("General", "Id", $mmdvmconfigs);
-    
+    $dmrID = ( ! empty($dmrGWID) ? $dmrGWID : getConfigItem("General", "Id", $mmdvmconfigs));
 
   // If there is a BM API Key
   $bmAPIurl = 'https://api.brandmeister.network/v1.0/repeater/';

--- a/mmdvmhost/bm_manager.php
+++ b/mmdvmhost/bm_manager.php
@@ -147,3 +147,4 @@ if ( $testMMDVModeDMR == 1 ) {
   }
 }
 
+?>

--- a/mmdvmhost/dapnet_messenger.php
+++ b/mmdvmhost/dapnet_messenger.php
@@ -27,7 +27,7 @@ if (isset($configdapnetapi['DAPNETAPI']['USER']) && (empty($configdapnetapi['DAP
     if ((empty($_POST) != TRUE) && (isset($_POST["dapSubmit"]) && (empty($_POST["dapSubmit"]) != TRUE)) && (isset($_POST["dapToCallsign"]) && (empty($_POST["dapToCallsign"]) != TRUE)) && (isset($_POST["dapMsgContent"]) && (empty($_POST["dapMsgContent"]) != TRUE))) {
         
         $dapnetTo = escapeshellcmd($_POST['dapToCallsign']);
-        $dapnetContent = trim($_POST['dapMsgContent']);
+        $dapnetContent = str_replace(array("\r\n", "\n", "\r"), "", $_POST['dapMsgContent']);
 
         $dapnetCmd = 'sudo /usr/local/sbin/pistar-dapnetapi '.$dapnetTo.' "'.$dapnetContent.'" nohost 2>&1';
         

--- a/mmdvmhost/dapnet_messenger.php
+++ b/mmdvmhost/dapnet_messenger.php
@@ -1,0 +1,77 @@
+<?php
+// Most of the work here contributed by geeks4hire (Ben Horan)
+
+include_once $_SERVER['DOCUMENT_ROOT'].'/config/config.php';          // MMDVMDash Config
+include_once $_SERVER['DOCUMENT_ROOT'].'/mmdvmhost/tools.php';        // MMDVMDash Tools
+include_once $_SERVER['DOCUMENT_ROOT'].'/mmdvmhost/functions.php';    // MMDVMDash Functions
+include_once $_SERVER['DOCUMENT_ROOT'].'/config/language.php';        // Translation Code
+
+// DAPNet API config 
+if (! isset($configdapnetapi)) {
+
+    if (file_exists('/etc/dapnetapi.key')) {
+        
+        $configDAPNetAPIConfigFile = '/etc/dapnetapi.key';
+        
+        if (fopen($configDAPNetAPIConfigFile,'r')) {
+            $configdapnetapi = parse_ini_file($configDAPNetAPIConfigFile, true);
+        }
+    }
+}
+
+if (isset($configdapnetapi['DAPNETAPI']['USER']) && (empty($configdapnetapi['DAPNETAPI']['USER']) != TRUE)):
+
+    $maxlength = (5 * (80 - (strlen($configdapnetapi['DAPNETAPI']['USER']) + 2 /* 'CALLSIGN: ' prefix */)));
+    
+    // Data has been posted for this page (POST)
+    if ((empty($_POST) != TRUE) && (isset($_POST["dapSubmit"]) && (empty($_POST["dapSubmit"]) != TRUE)) && (isset($_POST["dapToCallsign"]) && (empty($_POST["dapToCallsign"]) != TRUE)) && (isset($_POST["dapMsgContent"]) && (empty($_POST["dapMsgContent"]) != TRUE))) {
+        
+        $dapnetTo = escapeshellcmd($_POST['dapToCallsign']);
+        $dapnetContent = trim($_POST['dapMsgContent']);
+
+        $dapnetCmd = 'sudo /usr/local/sbin/pistar-dapnetapi '.$dapnetTo.' "'.$dapnetContent.'" nohost 2>&1';
+        
+        unset($dummy);
+        
+        ## Send POCSAG Page
+        $resultapi = exec($dapnetCmd, $dummy, $retValue);
+        
+        // Output to the browser
+        echo '<b>DAPNET Messenger</b>'."\n";
+        echo "<table>\n<tr><th>Command Output</th></tr>\n<tr><td>";
+        print $resultapi;
+        echo "</td></tr>\n</table>\n";
+        echo "<br />\n";
+
+        unset($_POST); // Cleanup
+        echo '<script type="text/javascript">setTimeout(function() { window.location=window.location;},5000);</script>';
+
+    }
+    else {
+    
+        echo '<b>DAPNET Messenger</b>'."\n";
+        echo '<form action="'.htmlentities($_SERVER['PHP_SELF']).'" method="post">'."\n";
+        echo '<table>
+		<tr>
+			<th><a class=tooltip href="#">To<span><b>Enter the destination callsign</b></span></a></th>
+			<th><a class=tooltip href="#">Message<span><b>Enter the message content</b></span></a></th>
+			<th><a class=tooltip href="#">Send<span><b>Send the message</b></span></a></th>
+		</tr>'."\n";
+        echo '  <tr>';
+        echo '    <td><input type="text" name="dapToCallsign" size="13" maxlength="12" value="" /></td>';
+        echo '    <td><textarea maxlength="'.$maxlength.'" name="dapMsgContent" cols="60" rows="3" style="overflow:scroll;" value="" /></textarea></td>';
+        echo '    <td><input type="submit" value="Send" name="dapSubmit" /></td>';
+        echo '  </tr>'."\n";
+        echo '</table>'."\n";
+
+    }
+
+else:
+    // Output to the browser
+    echo '<b>DAPNET Messenger</b>'."\n";
+    echo "<table>\n<tr><th>DISABLED</th></tr>\n<tr><td>";
+    print "DAPNET API configuration is incomplete";
+    echo "</td></tr>\n</table>\n";
+    echo "<br />\n";
+endif;
+?>


### PR DESCRIPTION
Don't erase POCSAG whitelist when disabling/enabling POCSAG mode.
bm_manager: add missing ?> tag
POCSAG: - Move dapnetapi config fields to configuration page, in POCSAG section.
        - Add dapnet GW and API edit and fulledit pages.
        - Add DAPNET messenger in admin page (use pistar-dapnetapi as backend).
Rename 'ircDDBGateway' to 'ircDDB GW' in expert header memu.