### PR TITLE
Always show selected MMDVM Display Port, even if not present or active at that moment

### DIFF
--- a/admin/configure.php
+++ b/admin/configure.php
@@ -2755,13 +2755,12 @@ else:
 	    <option <?php if (($configmmdvm['General']['Display'] == "None") || ($configmmdvm['General']['Display'] == "") ) {echo 'selected="selected" ';}; ?>value="None">None</option>
 	    <option <?php if ($configmmdvm['Nextion']['Port'] == "modem") {echo 'selected="selected" ';}; ?>value="modem">Modem</option>
 	    <option <?php if ($configmmdvm['Nextion']['Port'] == "/dev/ttyAMA0") {echo 'selected="selected" ';}; ?>value="/dev/ttyAMA0">/dev/ttyAMA0</option>
-	    <option <?php if ($configmmdvm['Nextion']['Port'] == "/dev/ttyUSB0") {echo 'selected="selected" ';}; ?>value="/dev/ttyUSB0">/dev/ttyUSB0</option>
-	    <?php if (file_exists('/dev/ttyS2')) { ?>
-	    	<option <?php if ($configmmdvm['Nextion']['Port'] == "/dev/ttyS2") {echo 'selected="selected" ';}; ?>value="/dev/ttyS2">/dev/ttyS2</option>
-    	    <?php } ?>
-	    <?php if (file_exists('/dev/ttyNextionDriver')) { ?>
-	    	<option <?php if ($configmmdvm['Nextion']['Port'] == "/dev/ttyNextionDriver") {echo 'selected="selected" ';}; ?>value="/dev/ttyNextionDriver">/dev/ttyNextionDriver</option>
-    	    <?php } ?>
+	    <?php if (file_exists('/dev/ttyUSB0')) $ACT=""; else $ACT=" (not present now)"; ?>
+	    <option <?php if ($configmmdvm['Nextion']['Port'] == "/dev/ttyUSB0") {echo 'selected="selected" ';}; ?>value="/dev/ttyUSB0">/dev/ttyUSB0<?php print $ACT; ?></option>
+	    <?php if (file_exists('/dev/ttyS2')) $ACT=""; else $ACT=" (not present now)"; ?>
+	    <option <?php if ($configmmdvm['Nextion']['Port'] == "/dev/ttyS2") {echo 'selected="selected" ';}; ?>value="/dev/ttyS2">/dev/ttyS2<?php print $ACT; ?></option>
+	    <?php if (file_exists('/dev/ttyNextionDriver')) $ACT=""; else $ACT=" (not active now)"; ?>
+	    <option <?php if ($configmmdvm['Nextion']['Port'] == "/dev/ttyNextionDriver") {echo 'selected="selected" ';}; ?>value="/dev/ttyNextionDriver">/dev/ttyNextionDriver<?php print $ACT; ?></option>
 	    </select>
 	    Nextion Layout: <select name="mmdvmNextionDisplayType">
 	    <option <?php if ($configmmdvm['Nextion']['ScreenLayout'] == "0") {echo 'selected="selected" ';}; ?>value="G4KLX">G4KLX</option>


### PR DESCRIPTION
Always fill the _MMDVM Display Type: Port_ dropdown with the possible devices, even if they are not present or active at that moment.
Also, when not present or not active, show it in the dropdown e.g. '/dev/ttyUSB0 (not present now)' or '/dev/ttyNextionDriver (not active now)'
This will prevent showing 'none' as port when the configured port is (temporary) unavailable: e.g. user forgot to plug in the USB/serial convertor or NextionDriver is not running.
It will also help users not being too confused when restoring a configuration on a host which lacks the selected port because of restoring to different hardware (e.g. /dev/ttyS0)
