### PR TITLE
Fix option for local YSF Parrot

### DIFF
--- a/admin/configure.php
+++ b/admin/configure.php
@@ -3392,10 +3392,10 @@ $ysfHosts = fopen("/usr/local/etc/YSFHosts.txt", "r"); ?>
                 $testYSFHost = "none";
                 echo "      <option value=\"none\" selected=\"selected\">None</option>\n";
     		}
-	if ($testYSFHost == "PARROT")  {
-		echo "      <option value=\"00001,PARROT\"  selected=\"selected\">YSF00001 - PARROT</option>\n";
+	if ($testYSFHost == "ZZ Parrot")  {
+		echo "      <option value=\"00001,ZZ Parrot\" selected=\"selected\">YSF00001 - Parrot</option>\n";
 	} else {
-		echo "      <option value=\"00001,PARROT\">YSF00001 - PARROT</option>\n";
+		echo "      <option value=\"00001,ZZ Parrot\">YSF00001 - Parrot</option>\n";
 	}
 	if ($testYSFHost == "YSF2DMR")  {
 		echo "      <option value=\"00002,YSF2DMR\"  selected=\"selected\">YSF00002 - Link YSF2DMR</option>\n";


### PR DESCRIPTION
Change ref. name to "ZZ Parrot" to match YSFGateway internal entry: https://github.com/g4klx/YSFClients/blob/70eeed653bde696636aa6c46aa15c1eb84a059ca/YSFGateway/YSFReflectors.cpp#L158

Note: without this change the PARROT entry was working but it was actually connecting to remote Parrot (the one hosted by DG9VH, now with ID 99999) instead of local Parrot as intended.