### PR TITLE
Add support for the Radioddity GD-77 running the OpenGD77 firmware as a modem type

### DIFF
--- a/admin/configure.php
+++ b/admin/configure.php
@@ -1637,6 +1637,16 @@ if ($_SERVER["PHP_SELF"] == "/admin/configure.php") {
 	    $configmmdvm['General']['Duplex'] = 0;
 	    $configmmdvm['DMR Network']['Slot1'] = 0;
 	  }
+	  
+	  if ( $confHardware == 'opengd77' ) {
+	    $rollModemType = 'sudo sed -i "/modemType=/c\\modemType=MMDVM" /etc/dstarrepeater';
+	    $rollRepeaterType1 = 'sudo sed -i "/repeaterType1=/c\\repeaterType1=0" /etc/ircddbgateway';
+	    system($rollModemType);
+	    system($rollRepeaterType1);
+	    $configmmdvm['Modem']['Port'] = "/dev/ttyACM0";
+	    $configmmdvm['General']['Duplex'] = 0;
+	    $configmmdvm['DMR Network']['Slot1'] = 0;
+	  }
 
 	  // Set the Service start delay
 	  system($rollDstarRepeaterStartDelay);
@@ -2952,6 +2962,7 @@ else:
 	        <option<?php if ($configModem['Modem']['Hardware'] === 'mmdvmvyehatdual') {	echo ' selected="selected"';}?> value="mmdvmvyehatdual">MMDVM_HS_Hat_Dual Hat (VR2VYE) for Pi (GPIO)</option>
 	    	<option<?php if ($configModem['Modem']['Hardware'] === 'nanodv') {		echo ' selected="selected"';}?> value="nanodv">MMDVM_NANO_DV (BG4TGO) for NanoPi AIR (GPIO)</option>
 	    	<option<?php if ($configModem['Modem']['Hardware'] === 'nanodvusb') {		echo ' selected="selected"';}?> value="nanodvusb">MMDVM_NANO_DV (BG4TGO) for NanoPi AIR (USB)</option>
+			<option<?php if ($configModem['Modem']['Hardware'] === 'opengd77') {	echo ' selected="selected"';}?> value="opengd77">OpenGD77 DMR hotspot (USB)</option>
     </select></td>
     </tr>
     <tr>

--- a/mmdvmhost/functions.php
+++ b/mmdvmhost/functions.php
@@ -382,6 +382,9 @@ function getDVModemFirmware() {
 		if (strpos($logLine, 'description: Nano_DV-')) {
 			$modemFirmware = "NanoDV:".strtok(substr($logLine, 75, 12), ' ');
 		}
+		if (strpos($logLine, 'description: OpenGD77 Hotspot')) {
+			$modemFirmware = "OpenGD77:".strtok(substr($logLine, 83, 12), ' ');
+		}
 	}
 	return $modemFirmware;
 }


### PR DESCRIPTION
Hi Andy

I'm going to release Hotspot mode for the OpenGD77 firmware (running on the Radioddity GD-77 radios), fairly soon and it would be good if at some point, you could include support for it in PiStar

However I realise at the moment this is a very niche hotspot, especially since its still only in beta test with about a dozen people.

I've changed what I think needs to be changed to add it as a Modem etc, but I don't know if there is any way to specify that the modem only works in DMR mode. 

No other modes are likely to be supported because the hardware in the GD-77 is dedicated to DMR (and FM) only.

See 

https://www.rogerclark.net/opengd77-hotspot-mode/

Thanks