### PR TITLE
Migrate OpenGD77 description text to new format

### DIFF
--- a/mmdvmhost/functions.php
+++ b/mmdvmhost/functions.php
@@ -385,6 +385,9 @@ function getDVModemFirmware() {
 		if (strpos($logLine, 'description: OpenGD77 Hotspot')) {
 			$modemFirmware = "OpenGD77:".strtok(substr($logLine, 83, 12), ' ');
 		}
+		if (strpos($logLine, 'description: OpenGD77_HS ')) {
+			$modemFirmware = "OpenGD77:".strtok(substr($logLine, 79, 12), ' ');
+		}		
 	}
 	return $modemFirmware;
 }


### PR DESCRIPTION
Now that Jonathan G4KLX has now accepted a PR to add the OpenGD77 Hotspot mode to MMDVMHost

https://github.com/g4klx/MMDVMHost/commit/95c1bbb8e630d39334e43e084d19b43f1648981f

This change adds support for the revised description string that has been accepted by Jonathan into the  MMDVMHost source code.


Note.
The existing description string handling has been retained, so that users who are running the older firmware will continue to see the description and version text. 
However in the longer term I will submit another PR to remove support for the old description format.

The OpenGD77 firmware will be updated to use the new description string in 
https://github.com/rogerclarkmelbourne/OpenGD77/pull/351
after this PR has been accepted 