### PR TITLE
preserve dmr extended id when applying changes with dmr mode disabled

### DIFF
--- a/admin/configure.php
+++ b/admin/configure.php
@@ -964,7 +964,7 @@ if ($_SERVER["PHP_SELF"] == "/admin/configure.php") {
 	  $newPostDmrId = preg_replace('/[^0-9]/', '', $_POST['dmrId']);
 	  $newPostDmrId = substr($newPostDmrId, 0, 7);
 	  $configmmdvm['General']['Id'] = $newPostDmrId;
-	  $configmmdvm['DMR']['Id'] = $newPostDmrId;
+	  $configmmdvm['DMR']['Id'] = $newPostDmrId . substr($configmmdvm['DMR']['Id'], 7);
 	  $configysfgateway['General']['Id'] = $newPostDmrId;
 	  $configdmrgateway['XLX Network']['Id'] = $newPostDmrId;
 	  $configdmr2ysf['DMR Network']['Id'] = $newPostDmrId;


### PR DESCRIPTION
currently dmr extended id is discarded every time we apply changes with dmr mode disabled but either ysf or p25 modes enabled (so that the id field shows), it's annoying to always loose dmr extended id when switching modes :)