### PR TITLE
remove colon from ysf "linked to" text allowing one extra char to show

### DIFF
--- a/mmdvmhost/repeaterinfo.php
+++ b/mmdvmhost/repeaterinfo.php
@@ -284,7 +284,7 @@ if ( $testMMDVModeYSF == 1 || $testDMR2YSF ) { //Hide the YSF information when S
                                 break;
                         }
                 }
-                if ($ysfLinkedToTxt != "null") { $ysfLinkedToTxt = "Room: ".$ysfLinkedToTxt; } else { $ysfLinkedToTxt = "Linked to: ".$ysfLinkedTo; }
+                if ($ysfLinkedToTxt != "null") { $ysfLinkedToTxt = "Room: ".$ysfLinkedToTxt; } else { $ysfLinkedToTxt = "Linked to ".$ysfLinkedTo; }
                 $ysfLinkedToTxt = str_replace('_', ' ', $ysfLinkedToTxt);
         }
         if (strlen($ysfLinkedToTxt) > 19) { $ysfLinkedToTxt = substr($ysfLinkedToTxt, 0, 17) . '..'; }


### PR DESCRIPTION
this allows to show "Linked to ZZ PARROT" instead of "Linked to: ZZ PAR..", also dstar "linked to" text doesn't either have a colon then removing it actually makes both match :)