### PR TITLE
added fns nd allow ysf2x manager on admin

### DIFF
--- a/admin/config_backup.php
+++ b/admin/config_backup.php
@@ -54,36 +54,38 @@ if ($_SERVER["PHP_SELF"] == "/admin/config_backup.php") {
           $output = "Finding config files to be backed up\n";
           $backupDir = "/tmp/config_backup";
           $backupZip = "/tmp/config_backup.zip";
-	  $hostNameInfo = exec('cat /etc/hostname');
+          $hostNameInfo = exec('cat /etc/hostname');
           
           $output .= shell_exec("sudo rm -rf $backupZip 2>&1");
           $output .= shell_exec("sudo rm -rf $backupDir 2>&1");
           $output .= shell_exec("sudo mkdir $backupDir 2>&1");
-	  if (shell_exec('cat /etc/dhcpcd.conf | grep "static ip_address" | grep -v "#"')) {
-		  $output .= shell_exec("sudo cp /etc/dhcpcd.conf $backupDir 2>&1");
-	  }
+          if (shell_exec('cat /etc/dhcpcd.conf | grep "static ip_address" | grep -v "#"')) {
+            $output .= shell_exec("sudo cp /etc/dhcpcd.conf $backupDir 2>&1");
+          }
           $output .= shell_exec("sudo cp /etc/wpa_supplicant/wpa_supplicant.conf $backupDir 2>&1");
           $output .= shell_exec("sudo cp /etc/ircddbgateway $backupDir 2>&1");
           $output .= shell_exec("sudo cp /etc/mmdvmhost $backupDir 2>&1");
           $output .= shell_exec("sudo cp /etc/dstarrepeater $backupDir 2>&1");
-	  $output .= shell_exec("sudo cp /etc/dapnetgateway $backupDir 2>&1");
+          $output .= shell_exec("sudo cp /etc/dapnetgateway $backupDir 2>&1");
           $output .= shell_exec("sudo cp /etc/p25gateway $backupDir 2>&1");
           $output .= shell_exec("sudo cp /etc/ysfgateway $backupDir 2>&1");
-	  $output .= shell_exec("sudo cp /etc/nxdngateway $backupDir 2>&1");
-	  $output .= shell_exec("sudo cp /etc/ysf2dmr $backupDir 2>&1");
-	  $output .= shell_exec("sudo cp /etc/dmrgateway $backupDir 2>&1");
-	  $output .= shell_exec("sudo cp /etc/mobilegps $backupDir 2>&1");
+          $output .= shell_exec("sudo cp /etc/nxdngateway $backupDir 2>&1");
+          $output .= shell_exec("sudo cp /etc/ysf2dmr $backupDir 2>&1");
+          $output .= shell_exec("sudo cp /etc/ysf2p25 $backupDir 2>&1");
+          $output .= shell_exec("sudo cp /etc/ysf2nxdn $backupDir 2>&1");
+          $output .= shell_exec("sudo cp /etc/dmrgateway $backupDir 2>&1");
+          $output .= shell_exec("sudo cp /etc/mobilegps $backupDir 2>&1");
           $output .= shell_exec("sudo cp /etc/starnetserver $backupDir 2>&1");
           $output .= shell_exec("sudo cp /etc/timeserver $backupDir 2>&1");
           $output .= shell_exec("sudo cp /etc/dstar-radio.* $backupDir 2>&1");
-	  $output .= shell_exec("sudo cp /etc/pistar-remote $backupDir 2>&1");
-	  $output .= shell_exec("sudo cp /etc/hosts $backupDir 2>&1");
-	  $output .= shell_exec("sudo cp /etc/hostname $backupDir 2>&1");
-	  $output .= shell_exec("sudo cp /etc/bmapi.key $backupDir 2>&1");
-	  $output .= shell_exec("sudo cp /etc/dapnetapi.key $backupDir 2>&1");
-	  $output .= shell_exec("sudo cp /usr/local/etc/RSSI.dat $backupDir 2>&1");
-	  $output .= shell_exec("sudo cp /var/www/dashboard/config/ircddblocal.php $backupDir 2>&1");
-	  $output .= shell_exec("sudo cp /var/www/dashboard/config/config.php $backupDir 2>&1");
+          $output .= shell_exec("sudo cp /etc/pistar-remote $backupDir 2>&1");
+          $output .= shell_exec("sudo cp /etc/hosts $backupDir 2>&1");
+          $output .= shell_exec("sudo cp /etc/hostname $backupDir 2>&1");
+          $output .= shell_exec("sudo cp /etc/bmapi.key $backupDir 2>&1");
+          $output .= shell_exec("sudo cp /etc/dapnetapi.key $backupDir 2>&1");
+          $output .= shell_exec("sudo cp /usr/local/etc/RSSI.dat $backupDir 2>&1");
+          $output .= shell_exec("sudo cp /var/www/dashboard/config/ircddblocal.php $backupDir 2>&1");
+          $output .= shell_exec("sudo cp /var/www/dashboard/config/config.php $backupDir 2>&1");
           $output .= "Compressing backup files\n";
           $output .= shell_exec("sudo zip -j $backupZip $backupDir/* 2>&1");
           $output .= "Starting download\n";
@@ -99,12 +101,12 @@ if ($_SERVER["PHP_SELF"] == "/admin/config_backup.php") {
             $local_time = $dt->format('d-M-Y');
             header('Content-Description: File Transfer');
             header('Content-Type: application/octet-stream');
-	    if ($hostNameInfo != "pi-star") {
-		    header('Content-Disposition: attachment; filename="'.basename("Pi-Star_Config_".$hostNameInfo."_".$local_time.".zip").'"');
-	    }
-	    else {
-		    header('Content-Disposition: attachment; filename="'.basename("Pi-Star_Config_$local_time.zip").'"');
-	    }
+            if ($hostNameInfo != "pi-star") {
+            	header('Content-Disposition: attachment; filename="'.basename("Pi-Star_Config_".$hostNameInfo."_".$local_time.".zip").'"');
+            }
+            else {
+            	header('Content-Disposition: attachment; filename="'.basename("Pi-Star_Config_$local_time.zip").'"');
+            }
             header('Content-Transfer-Encoding: binary');
             header('Expires: 0');
             header('Cache-Control: must-revalidate');
@@ -125,8 +127,8 @@ if ($_SERVER["PHP_SELF"] == "/admin/config_backup.php") {
           shell_exec("sudo rm -rf $target_dir 2>&1");
           shell_exec("mkdir $target_dir 2>&1");
           if($_FILES["fileToUpload"]["name"]) {
-                  $filename = $_FILES["fileToUpload"]["name"];
-	  	  $source = $_FILES["fileToUpload"]["tmp_name"];
+              $filename = $_FILES["fileToUpload"]["name"];
+	  	      $source = $_FILES["fileToUpload"]["tmp_name"];
 	          $type = $_FILES["fileToUpload"]["type"];
 	
 	          $name = explode(".", $filename);
@@ -135,9 +137,9 @@ if ($_SERVER["PHP_SELF"] == "/admin/config_backup.php") {
 		          if($mime_type == $type) {
 			          $okay = true;
 			          break;
-			  }
-		  }
-	  }
+			  	  }
+		  	  }
+	  	  }
 		$continue = strtolower($name[1]) == 'zip' ? true : false;
 	        if(!$continue) {
 		        $output .= "The file you are trying to upload is not a .zip file. Please try again.\n";
@@ -165,6 +167,8 @@ if ($_SERVER["PHP_SELF"] == "/admin/config_backup.php") {
 			shell_exec('sudo systemctl stop pistar-remote.service 2>&1');	//PiStar-Remote Service
 			shell_exec('sudo systemctl stop ysfgateway.service 2>&1');	//YSFGateway
 			shell_exec('sudo systemctl stop ysf2dmr.service 2>&1');		//YSF2DMR
+			shell_exec('sudo systemctl stop ysf2p25.service 2>&1');		//YSF2P25
+			shell_exec('sudo systemctl stop ysf2nxdn.service 2>&1');		//YSF2NXDN
 			shell_exec('sudo systemctl stop p25gateway.service 2>&1');	//P25Gateway
 			shell_exec('sudo systemctl stop dapnetgateway.service 2>&1');	//DAPNETGateway
 			shell_exec('sudo systemctl stop mobilegps.service 2>&1');	//MobileGPS
@@ -206,6 +210,8 @@ if ($_SERVER["PHP_SELF"] == "/admin/config_backup.php") {
 			}
 			shell_exec('sudo systemctl start ysfgateway.service 2>&1');		//YSFGateway
 			shell_exec('sudo systemctl start ysf2dmr.service 2>&1');		//YSF2DMR
+			shell_exec('sudo systemctl start ysf2p25.service 2>&1');		//YSF2P25
+			shell_exec('sudo systemctl start ysf2nxdn.service 2>&1');		//YSF2NXDN
 			shell_exec('sudo systemctl start p25gateway.service 2>&1');		//P25Gateway
 			shell_exec('sudo systemctl start dapnetgateway.service 2>&1');		//DAPNETGateway
 			shell_exec('sudo systemctl start mobilegps.service 2>&1');		//MobileGPS

--- a/admin/config_backup.php
+++ b/admin/config_backup.php
@@ -73,6 +73,8 @@ if ($_SERVER["PHP_SELF"] == "/admin/config_backup.php") {
           $output .= shell_exec("sudo cp /etc/ysf2dmr $backupDir 2>&1");
           $output .= shell_exec("sudo cp /etc/ysf2p25 $backupDir 2>&1");
           $output .= shell_exec("sudo cp /etc/ysf2nxdn $backupDir 2>&1");
+          $output .= shell_exec("sudo cp /etc/dmr2ysf $backupDir 2>&1");
+          $output .= shell_exec("sudo cp /etc/dmr2nxdn $backupDir 2>&1");
           $output .= shell_exec("sudo cp /etc/dmrgateway $backupDir 2>&1");
           $output .= shell_exec("sudo cp /etc/mobilegps $backupDir 2>&1");
           $output .= shell_exec("sudo cp /etc/starnetserver $backupDir 2>&1");
@@ -168,7 +170,9 @@ if ($_SERVER["PHP_SELF"] == "/admin/config_backup.php") {
 			shell_exec('sudo systemctl stop ysfgateway.service 2>&1');	//YSFGateway
 			shell_exec('sudo systemctl stop ysf2dmr.service 2>&1');		//YSF2DMR
 			shell_exec('sudo systemctl stop ysf2p25.service 2>&1');		//YSF2P25
-			shell_exec('sudo systemctl stop ysf2nxdn.service 2>&1');		//YSF2NXDN
+			shell_exec('sudo systemctl stop ysf2nxdn.service 2>&1');	//YSF2NXDN
+			shell_exec('sudo systemctl stop dmr2ysf.service 2>&1');		//DMR2YSF
+			shell_exec('sudo systemctl stop dmr2nxdn.service 2>&1');	//DMR2NXDN
 			shell_exec('sudo systemctl stop p25gateway.service 2>&1');	//P25Gateway
 			shell_exec('sudo systemctl stop dapnetgateway.service 2>&1');	//DAPNETGateway
 			shell_exec('sudo systemctl stop mobilegps.service 2>&1');	//MobileGPS
@@ -212,6 +216,8 @@ if ($_SERVER["PHP_SELF"] == "/admin/config_backup.php") {
 			shell_exec('sudo systemctl start ysf2dmr.service 2>&1');		//YSF2DMR
 			shell_exec('sudo systemctl start ysf2p25.service 2>&1');		//YSF2P25
 			shell_exec('sudo systemctl start ysf2nxdn.service 2>&1');		//YSF2NXDN
+			shell_exec('sudo systemctl start dmr2ysf.service 2>&1');		//DMR2YSF
+			shell_exec('sudo systemctl start dmr2nxdn.service 2>&1');	    //DMR2NXDN
 			shell_exec('sudo systemctl start p25gateway.service 2>&1');		//P25Gateway
 			shell_exec('sudo systemctl start dapnetgateway.service 2>&1');		//DAPNETGateway
 			shell_exec('sudo systemctl start mobilegps.service 2>&1');		//MobileGPS

--- a/dstarrepeater/system.php
+++ b/dstarrepeater/system.php
@@ -21,8 +21,8 @@ $cpuLoad = sys_getloadavg();
 $cpuTempCRaw = exec('cat /sys/class/thermal/thermal_zone0/temp');
 if ($cpuTempCRaw > 1000) { $cpuTempC = round($cpuTempCRaw / 1000, 1); } else { $cpuTempC = round($cpuTempCRaw, 1); }
 $cpuTempF = round(+$cpuTempC * 9 / 5 + 32, 1);
-if ($cpuTempC < 50) { $cpuTempHTML = "<td style=\"background: #1d1\">".$cpuTempC."&deg;C / ".$cpuTempF."&deg;F</td>\n"; }
-if ($cpuTempC >= 50) { $cpuTempHTML = "<td style=\"background: #fa0\">".$cpuTempC."&deg;C / ".$cpuTempF."&deg;F</td>\n"; }
+if ($cpuTempC < 60) { $cpuTempHTML = "<td style=\"background: #1d1\">".$cpuTempC."&deg;C / ".$cpuTempF."&deg;F</td>\n"; }
+if ($cpuTempC >= 60) { $cpuTempHTML = "<td style=\"background: #fa0\">".$cpuTempC."&deg;C / ".$cpuTempF."&deg;F</td>\n"; }
 if ($cpuTempC >= 69) { $cpuTempHTML = "<td style=\"background: #f00\">".$cpuTempC."&deg;C / ".$cpuTempF."&deg;F</td>\n"; }
 ?>
 <b><?php echo $lang['hardware_info'];?></b>

--- a/index.php
+++ b/index.php
@@ -175,24 +175,15 @@ if (file_exists('/etc/dstar-radio.mmdvmhost')) {
 	}
 	if ($_SERVER["PHP_SELF"] == "/admin/index.php") {               // Admin Only Options
                 include 'mmdvmhost/tgif_manager.php';			// TGIF DMR Link Manager
-        }
-	$testMMDVModeYSFnet = getConfigItem("System Fusion Network", "Enable", $mmdvmconfigs);
-        if ( $testMMDVModeYSFnet == 1 ) {				// If YSF network is enabled, add these extra features.
-		if ($_SERVER["PHP_SELF"] == "/admin/index.php") { 	// Admin Only Option
-			include 'mmdvmhost/ysf_manager.php';		// YSF Links
-		}
+    }
+	if ($_SERVER["PHP_SELF"] == "/admin/index.php") { 	// Admin Only Option
+		include 'mmdvmhost/ysf_manager.php';		// YSF Links
 	}
-	$testMMDVModeP25net = getConfigItem("P25 Network", "Enable", $mmdvmconfigs);
-        if ( $testMMDVModeP25net == 1 ) {				// If P25 network is enabled, add these extra features.
-		if ($_SERVER["PHP_SELF"] == "/admin/index.php") { 	// Admin Only Option
-			include 'mmdvmhost/p25_manager.php';		// P25 Links
-		}
+	if ($_SERVER["PHP_SELF"] == "/admin/index.php") { 	// Admin Only Option
+		include 'mmdvmhost/p25_manager.php';		// P25 Links
 	}
-	$testMMDVModeNXDNnet = getConfigItem("NXDN Network", "Enable", $mmdvmconfigs);
-        if ( $testMMDVModeNXDNnet == 1 ) {				// If NXDN network is enabled, add these extra features.
-		if ($_SERVER["PHP_SELF"] == "/admin/index.php") { 	// Admin Only Option
-			include 'mmdvmhost/nxdn_manager.php';		// NXDN Links
-		}
+	if ($_SERVER["PHP_SELF"] == "/admin/index.php") { 	// Admin Only Option
+		include 'mmdvmhost/nxdn_manager.php';		// NXDN Links
 	}
 	echo '<script type="text/javascript">'."\n";
 	echo 'function reloadLocalTx(){'."\n";

--- a/mmdvmhost/bm_links.php
+++ b/mmdvmhost/bm_links.php
@@ -5,9 +5,7 @@ include_once $_SERVER['DOCUMENT_ROOT'].'/mmdvmhost/functions.php';    // MMDVMDa
 include_once $_SERVER['DOCUMENT_ROOT'].'/config/language.php';        // Translation Code
 
 // Check if DMR is Enabled
-$testMMDVModeDMR = getConfigItem("DMR", "Enable", $mmdvmconfigs);
-
-if ( $testMMDVModeDMR == 1 ) {
+if ( isDMREnabled() ) {
   //setup BM API Key
   $bmAPIkeyFile = '/etc/bmapi.key';
   if (file_exists($bmAPIkeyFile) && fopen($bmAPIkeyFile,'r')) { $configBMapi = parse_ini_file($bmAPIkeyFile, true);

--- a/mmdvmhost/bm_manager.php
+++ b/mmdvmhost/bm_manager.php
@@ -5,9 +5,7 @@ include_once $_SERVER['DOCUMENT_ROOT'].'/mmdvmhost/functions.php';    // MMDVMDa
 include_once $_SERVER['DOCUMENT_ROOT'].'/config/language.php';        // Translation Code
 
 // Check if DMR is Enabled
-$testMMDVModeDMR = getConfigItem("DMR", "Enable", $mmdvmconfigs);
-
-if ( $testMMDVModeDMR == 1 ) {
+if ( isDMREnabled() ) {
   //setup BM API Key
   $bmAPIkeyFile = '/etc/bmapi.key';
   if (file_exists($bmAPIkeyFile) && fopen($bmAPIkeyFile,'r')) {

--- a/mmdvmhost/functions.php
+++ b/mmdvmhost/functions.php
@@ -1117,4 +1117,98 @@ if (!in_array($_SERVER["PHP_SELF"],array('/mmdvmhost/bm_links.php','/mmdvmhost/b
 		$logLinesDAPNETGateway = getDAPNETGatewayLog();
 	}
 }
+
+function isDStarEnabled(){
+	$mmdvmconfigs = getMMDVMConfig();
+	return getConfigItem("D-Star", "Enable", $mmdvmconfigs);
+}
+
+function isYSFEnabled(){
+	$mmdvmconfigs = getMMDVMConfig();
+	return getConfigItem("System Fusion Network", "Enable", $mmdvmconfigs);
+}
+
+function isP25Enabled(){
+	$mmdvmconfigs = getMMDVMConfig();
+	return getConfigItem("P25 Network", "Enable", $mmdvmconfigs);
+}
+
+function isNXDNEnabled(){
+	$mmdvmconfigs = getMMDVMConfig();
+	return getConfigItem("NXDN Network", "Enable", $mmdvmconfigs);
+}
+
+function isDMREnabled(){
+	$mmdvmconfigs = getMMDVMConfig();
+	return getConfigItem("DMR", "Enable", $mmdvmconfigs);
+}
+
+function isPOCSAGEnabled(){
+	$mmdvmconfigs = getMMDVMConfig();
+	return getConfigItem("POCSAG Network", "Enable", $mmdvmconfigs);
+}
+
+function isYSF2DMREnabled(){
+	$file = '/etc/ysf2dmr';
+	return isx2xEnabled($file);
+}
+
+function isYSF2P25Enabled(){
+	$file = '/etc/ysf2p25';
+	return isx2xEnabled($file);
+}
+
+function isYSF2NXDNEnabled(){
+	$file = '/etc/ysf2nxdn';
+	return isx2xEnabled($file);
+}
+
+function isDMR2YSFEnabled(){
+	$file = '/etc/dmr2ysf';
+	return isx2xEnabled($file);
+}
+
+function isDMR2NXDNEnabled(){
+	$file = '/etc/dmr2nxdn';
+	return isx2xEnabled($file);
+}
+
+function isP252DMREnabled(){
+	$file = '/etc/p252dmr';
+	return isx2xEnabled($file);
+}
+
+function isx2xEnabled($file){
+	if (fopen($file,'r')) {
+		$x2xGatewayConfig = parse_ini_file($file, true);
+		return $x2xGatewayConfig['Enabled']['Enabled'];
+	} else {
+		return false;
+	}
+}
+
+function getP25ConfigItem($section, $key) {
+	//Load the p25gateway config file
+	$p25GatewayConfigFile = '/etc/p25gateway';
+	if (fopen($p25GatewayConfigFile,'r')) { $configp25gateway = parse_ini_file($p25GatewayConfigFile, true); }
+
+	return $configp25gateway[$section][$key];
+}
+
+function getYSFConfigItem($section, $key) {
+	//Load the ysfgateway config file
+	$ysfGatewayConfigFile = '/etc/ysfgateway';
+	if (fopen($ysfGatewayConfigFile,'r')) { $configysfgateway = parse_ini_file($ysfGatewayConfigFile, true); }
+
+	return $configysfgateway[$section][$key];
+}
+
+function getNXDNConfigItem($section, $key) {
+	//Load the nxdngateway config file
+	$nxdnGatewayConfigFile = '/etc/nxdngateway';
+	if (fopen($nxdnGatewayConfigFile,'r')) { $confignxdngateway = parse_ini_file($nxdnGatewayConfigFile, true); }
+
+	return $confignxdngateway[$section][$key];
+}
+
 ?>

--- a/mmdvmhost/nxdn_manager.php
+++ b/mmdvmhost/nxdn_manager.php
@@ -5,16 +5,11 @@ include_once $_SERVER['DOCUMENT_ROOT'].'/mmdvmhost/functions.php';    // MMDVMDa
 include_once $_SERVER['DOCUMENT_ROOT'].'/config/language.php';        // Translation Code
 
 // Check if NXDN is Enabled
-$testMMDVModeNXDN = getConfigItem("NXDN Network", "Enable", $mmdvmconfigs);
-if ( $testMMDVModeNXDN == 1 ) {
-
-  //Load the nxdngateway config file
-  $nxdnGatewayConfigFile = '/etc/nxdngateway';
-  if (fopen($nxdnGatewayConfigFile,'r')) { $confignxdngateway = parse_ini_file($nxdnGatewayConfigFile, true); }
+if ( isNXDNEnabled() || isYSF2NXDNEnabled()) {
 
   // Check that the remote is enabled
-  if ( $confignxdngateway['Remote Commands']['Enable'] == 1 ) {
-    $remotePort = $confignxdngateway['Remote Commands']['Port'];
+  if ( getNXDNConfigItem('Remote Commands', 'Enable') == 1 ) {
+    $remotePort = getNXDNConfigItem('Remote Commands', 'Port');
     if (!empty($_POST) && isset($_POST["nxdnMgrSubmit"])) {
       // Handle Posted Data
       if (preg_match('/[^A-Za-z0-9]/',$_POST['nxdnLinkHost'])) { unset ($_POST['nxdnLinkHost']);}
@@ -22,7 +17,12 @@ if ( $testMMDVModeNXDN == 1 ) {
 	if ($_POST['nxdnLinkHost'] == "none") {
 	  $remoteCommand = "cd /var/log/pi-star && sudo /usr/local/bin/RemoteCommand ".$remotePort." TalkGroup9999";
 	} else {
-	  $remoteCommand = "cd /var/log/pi-star && sudo /usr/local/bin/RemoteCommand ".$remotePort." TalkGroup".$_POST['nxdnLinkHost'];
+	  if(isNXDNEnabled() == 0 && isYSF2NXDNEnabled() == 1){
+	    $ysfRemotePort = getYSFConfigItem('Remote Commands', 'Port');
+	    $remoteCommand = "cd /var/log/pi-star && sudo /usr/local/bin/RemoteCommand ".$ysfRemotePort." LinkYSF00003 && sudo /usr/local/bin/RemoteCommand ".$remotePort." TalkGroup".$_POST['nxdnLinkHost'];
+	  } else {
+	    $remoteCommand = "cd /var/log/pi-star && sudo /usr/local/bin/RemoteCommand ".$remotePort." TalkGroup".$_POST['nxdnLinkHost'];
+	  }
 	}
       } elseif ($_POST["Link"] == "UNLINK") {
 	$remoteCommand = "cd /var/log/pi-star && sudo /usr/local/bin/RemoteCommand ".$remotePort." TalkGroup9999";
@@ -65,7 +65,7 @@ if ( $testMMDVModeNXDN == 1 ) {
             <select name="nxdnLinkHost">
             <?php
             $nxdnHosts = fopen("/usr/local/etc/NXDNHosts.txt", "r");
-            if (isset($confignxdngateway['Network']['Startup'])) { $testNXDNHost = $confignxdngateway['Network']['Startup']; } else { $testNXDNHost = ""; }
+            if (getNXDNConfigItem('Network', 'Startup')) { $testNXDNHost = getNXDNConfigItem('Network', 'Startup'); } else { $testNXDNHost = ""; }
             if ($testNXDNHost == "") { echo "      <option value=\"none\" selected=\"selected\">None</option>\n"; }
                   else { echo "      <option value=\"none\">None</option>\n"; }
             if ($testNXDNHost == "10") { echo "      <option value=\"10\" selected=\"selected\">10 - Parrot</option>\n"; }

--- a/mmdvmhost/repeaterinfo.php
+++ b/mmdvmhost/repeaterinfo.php
@@ -140,7 +140,7 @@ if (isset($lastHeard[0])) {
 		}
 	}
 else {
-	echo "<td></td>";
+    echo "<td style=\"background:#0b0; color:#030;\">Listening</td>";
 }
 ?></tr>
 <tr><th>Tx</th><td style="background: #ffffff;"><?php echo getMHZ(getConfigItem("Info", "TXFrequency", $mmdvmconfigs)); ?></td></tr>
@@ -156,8 +156,7 @@ echo '<tr><th>TCXO</th><td style="background: #ffffff;">'.getDVModemTCXOFreq().'
 </table>
 
 <?php
-$testMMDVModeDSTAR = getConfigItem("D-Star", "Enable", $mmdvmconfigs);
-if ( $testMMDVModeDSTAR == 1 ) { //Hide the D-Star Reflector information when D-Star Network not enabled.
+if ( isDStarEnabled() ) { //Hide the D-Star Reflector information when D-Star Network not enabled.
 echo "<br />\n";
 echo "<table>\n";
 echo "<tr><th colspan=\"2\">".$lang['dstar_repeater']."</th></tr>\n";
@@ -170,8 +169,7 @@ echo "<tr><td colspan=\"2\" style=\"background: #ffffff;\">".getActualLink($reve
 echo "</table>\n";
 }
 
-$testMMDVModeDMR = getConfigItem("DMR", "Enable", $mmdvmconfigs);
-if ( $testMMDVModeDMR == 1 ) { //Hide the DMR information when DMR mode not enabled.
+if ( isDMREnabled() ) { //Hide the DMR information when DMR mode not enabled.
 $dmrMasterFile = fopen("/usr/local/etc/DMR_Hosts.txt", "r");
 $dmrMasterHost = getConfigItem("DMR Network", "Address", $mmdvmconfigs);
 $dmrMasterPort = getConfigItem("DMR Network", "Port", $mmdvmconfigs);
@@ -264,9 +262,7 @@ if (getEnabled("DMR Network", $mmdvmconfigs) == 1) {
 echo "</table>\n";
 }
 
-$testMMDVModeYSF = getConfigItem("System Fusion Network", "Enable", $mmdvmconfigs);
-if ( isset($configdmr2ysf['Enabled']['Enabled']) ) { $testDMR2YSF = $configdmr2ysf['Enabled']['Enabled']; }
-if ( $testMMDVModeYSF == 1 || $testDMR2YSF ) { //Hide the YSF information when System Fusion Network mode not enabled.
+if ( isYSFEnabled() || isDMR2YSFEnabled() ) { //Hide the YSF information when System Fusion Network mode not enabled.
         $ysfLinkedTo = getActualLink($reverseLogLinesYSFGateway, "YSF");
         if ($ysfLinkedTo == 'Not Linked' || $ysfLinkedTo == 'Service Not Started') {
                 $ysfLinkedToTxt = $ysfLinkedTo;
@@ -293,8 +289,7 @@ if ( $testMMDVModeYSF == 1 || $testDMR2YSF ) { //Hide the YSF information when S
         echo "</table>\n";
 }
 
-if ( isset($configysf2dmr['Enabled']['Enabled']) ) { $testYSF2DMR = $configysf2dmr['Enabled']['Enabled']; }
-if ( $testYSF2DMR ) { //Hide the YSF2DMR information when YSF2DMR Network mode not enabled.
+if ( isYSF2DMREnabled() ) { //Hide the YSF2DMR information when YSF2DMR Network mode not enabled.
         $dmrMasterFile = fopen("/usr/local/etc/DMR_Hosts.txt", "r");
         $dmrMasterHost = $configysf2dmr['DMR Network']['Address'];
         while (!feof($dmrMasterFile)) {
@@ -316,9 +311,7 @@ if ( $testYSF2DMR ) { //Hide the YSF2DMR information when YSF2DMR Network mode n
         echo "</table>\n";
 }
 
-$testMMDVModeP25 = getConfigItem("P25 Network", "Enable", $mmdvmconfigs);
-if ( isset($configysf2p25['Enabled']['Enabled']) ) { $testYSF2P25 = $configysf2p25['Enabled']['Enabled']; }
-if ( $testMMDVModeP25 == 1 || $testYSF2P25 ) { //Hide the P25 information when P25 Network mode not enabled.
+if ( isP25Enabled() || isYSF2P25Enabled() ) { //Hide the P25 information when P25 Network mode not enabled.
 	echo "<br />\n";
 	echo "<table>\n";
 	if (getConfigItem("P25", "NAC", $mmdvmconfigs)) {
@@ -330,10 +323,7 @@ if ( $testMMDVModeP25 == 1 || $testYSF2P25 ) { //Hide the P25 information when P
 	echo "</table>\n";
 }
 
-$testMMDVModeNXDN = getConfigItem("NXDN Network", "Enable", $mmdvmconfigs);
-if ( isset($configysf2nxdn['Enabled']['Enabled']) ) { if ($configysf2nxdn['Enabled']['Enabled'] == 1) { $testYSF2NXDN = 1; } }
-if ( isset($configdmr2nxdn['Enabled']['Enabled']) ) { if ($configdmr2nxdn['Enabled']['Enabled'] == 1) { $testDMR2NXDN = 1; } }
-if ( $testMMDVModeNXDN == 1 || isset($testYSF2NXDN) || isset($testDMR2NXDN) ) { //Hide the NXDN information when NXDN Network mode not enabled.
+if ( isNXDNEnabled() || isYSF2NXDNEnabled() || isDMR2NXDNEnabled() ) { //Hide the NXDN information when NXDN Network mode not enabled.
 	echo "<br />\n";
 	echo "<table>\n";
 	if (getConfigItem("NXDN", "RAN", $mmdvmconfigs)) {
@@ -349,8 +339,7 @@ if ( $testMMDVModeNXDN == 1 || isset($testYSF2NXDN) || isset($testDMR2NXDN) ) { 
 	echo "</table>\n";
 }
 
-$testMMDVModePOCSAG = getConfigItem("POCSAG Network", "Enable", $mmdvmconfigs);
-if ( $testMMDVModePOCSAG == 1 ) { //Hide the POCSAG information when POCSAG Network mode not enabled.
+if ( isPOCSAGEnabled() ) { //Hide the POCSAG information when POCSAG Network mode not enabled.
 	echo "<br />\n";
 	echo "<table>\n";
 	echo "<tr><th colspan=\"2\">POCSAG</th></tr>\n";

--- a/mmdvmhost/tgif_links.php
+++ b/mmdvmhost/tgif_links.php
@@ -11,9 +11,7 @@ $slot2tg = "";
 $dmrID = "";
 
 // Check if DMR is Enabled
-$testMMDVModeDMR = getConfigItem("DMR", "Enable", $mmdvmconfigs);
-
-if ( $testMMDVModeDMR == 1 ) {
+if ( isDMREnabled() ) {
   //Load the dmrgateway config file
   $dmrGatewayConfigFile = '/etc/dmrgateway';
   if (fopen($dmrGatewayConfigFile,'r')) { $configdmrgateway = parse_ini_file($dmrGatewayConfigFile, true); }

--- a/mmdvmhost/tgif_manager.php
+++ b/mmdvmhost/tgif_manager.php
@@ -63,9 +63,7 @@ function httpStatusText($code = 0) {
 $dmrID = "";
 
 // Check if DMR is Enabled
-$testMMDVModeDMR = getConfigItem("DMR", "Enable", $mmdvmconfigs);
-
-if ( $testMMDVModeDMR == 1 ) {
+if ( isDMREnabled() ) {
   //Load the dmrgateway config file
   $dmrGatewayConfigFile = '/etc/dmrgateway';
   if (fopen($dmrGatewayConfigFile,'r')) { $configdmrgateway = parse_ini_file($dmrGatewayConfigFile, true); }

--- a/mmdvmhost/ysf_manager.php
+++ b/mmdvmhost/ysf_manager.php
@@ -5,16 +5,11 @@ include_once $_SERVER['DOCUMENT_ROOT'].'/mmdvmhost/functions.php';    // MMDVMDa
 include_once $_SERVER['DOCUMENT_ROOT'].'/config/language.php';        // Translation Code
 
 // Check if YSF is Enabled
-$testMMDVModeYSF = getConfigItem("System Fusion Network", "Enable", $mmdvmconfigs);
-if ( $testMMDVModeYSF == 1 ) {
-
-  //Load the ysfgateway config file
-  $ysfGatewayConfigFile = '/etc/ysfgateway';
-  if (fopen($ysfGatewayConfigFile,'r')) { $configysfgateway = parse_ini_file($ysfGatewayConfigFile, true); }
+if ( isYSFEnabled() ) {
 
   // Check that the remote is enabled
-  if ( $configysfgateway['Remote Commands']['Enable'] == 1 ) {
-    $remotePort = $configysfgateway['Remote Commands']['Port'];
+  if ( getYSFConfigItem('Remote Commands','Enable') == 1 ) {
+    $remotePort = getYSFConfigItem('Remote Commands','Port');
     if (!empty($_POST) && isset($_POST["ysfMgrSubmit"])) {
       // Handle Posted Data
       if (preg_match('/[^A-Za-z0-9]/',$_POST['ysfLinkHost'])) { unset ($_POST['ysfLinkHost']);}
@@ -64,8 +59,8 @@ if ( $testMMDVModeYSF == 1 ) {
           <td>
             <select name="ysfLinkHost">
             <?php
-	      if (isset($configysfgateway['Network']['Startup'])) {
-                $testYSFHost = $configysfgateway['Network']['Startup'];
+	      if (getYSFConfigItem('Network', 'Startup')) {
+                $testYSFHost = getYSFConfigItem('Network','Startup');
                 echo "      <option value=\"none\">None</option>\n";
         	}
         else {


### PR DESCRIPTION
1: Updated temp color, now temp upto 60c will show up green as while stressing the pi easily goes to 50c, just a suggestion can revert it back
2: Added listening to Trx column on startup as it remains blank and gives impression that device is still booting up and services have not started yet.
3: removed check from ysf, p25 and nxdn to see if they are enabled while importing them as we are already doing so again in the manager file
4: enabled p25 and nxdn manager when ysf2p25 or ysf2nxdn is enabled, also changing reflector in p25 or nxdn changes ysf mode to join the p25 or nxdn room only when the standalone modes are disabled and only ysf2x is enabled.
5: changed code to reuse is a mode enabled case fn. 
6: Added Ysf2p25, Ysf2nxdn, Dmr2Ysf and Dmr2NXDN to backup and restore


I am not a php dev so please let me know if something is wrong or needs to be changed or any pointer or any issues let me know.

This was essentially done as devices like ft70dr cannot connect to 6 digit dmr rooms, this is starting point to adding option to change rooms from admin panel. I have a dmr radio on order which I can use to further test any dmr features as well.