### PR TITLE
Fix double quotes around password

### DIFF
--- a/admin/expert/edit_mmdvmhost.php
+++ b/admin/expert/edit_mmdvmhost.php
@@ -61,7 +61,7 @@ if($_POST) {
 			$content .= "[".$section."]\n";
 			//append the values
 			foreach($values as $key=>$value) {
-				if ($section == "DMR Network" && $key == "Options" && $value) {
+				if ($section == "DMR Network" && $key == "Password" && $value) {
 					$value = str_replace('"', "", $value);
 					$content .= $key."=\"".$value."\"\n";
 				}


### PR DESCRIPTION
This section of code largely doesn't evaluate.  If a special character is used in the password it will render the configuration file unreadable.  Changing $key to test for "Password" will then put double quotes around the password and things will work as expected.  The next stanza that checks for Options as well probably should be looked at but I don't know what it is intended to do.
More info here: https://forum.pistar.uk/viewtopic.php?f=3&t=2859&p=14117#p14117