### PR TITLE
Fix RSSI display value

### DIFF
--- a/mmdvmhost/functions.php
+++ b/mmdvmhost/functions.php
@@ -528,7 +528,7 @@ function getHeardList($logLines) {
 				if (array_key_exists(4,$lineTokens) && startsWith($lineTokens[4],"RSSI")) {
 					$rssi = substr($lineTokens[4], 6);
 					$dBraw = substr($rssi, strrpos($rssi,'/')+1); //average only
-					$relint = intval($dBraw) + 93;
+					$relint = intval($dBraw) + 73;
 					$signal = round(($relint/6)+9, 0);
 					if ($signal < 0) $signal = 0;
 					if ($signal > 9) $signal = 9;


### PR DESCRIPTION
The S part of the RSSI display value is wrong and does not match the dBm value shown next to it. For example -23dBm displays as **S9+70dB**, the correct S meter value for -23dBm is **S9+50dB** since the signal is 50dB above S9 (-73dBm). (https://en.wikipedia.org/wiki/S_meter).

Here is an example illustrating the wrong S display: 
<img width="652" alt="Screen Shot 2020-07-06 at 10 21 35 pm" src="https://user-images.githubusercontent.com/13449883/86592576-176b4000-bfd7-11ea-9f35-5c7203033e98.png">

Same display with corrected code:
<img width="649" alt="Screen Shot 2020-07-06 at 10 23 26 pm" src="https://user-images.githubusercontent.com/13449883/86592745-5e593580-bfd7-11ea-90f1-3bb49e6dc1e8.png">
 