### PR TITLE
Added detection of timed out DMR calls in getHeardList()

### DIFF
--- a/mmdvmhost/functions.php
+++ b/mmdvmhost/functions.php
@@ -510,7 +510,7 @@ function getHeardList($logLines) {
 			if (array_key_exists(3,$lineTokens)) {
 				$loss = $lineTokens[3];
 			}
-			if (strpos($logLine,"RF user has timed out")) {
+			if (strpos($logLine,"RF user has timed out") || strpos($logLine,"watchdog has expired")) {
 				$duration = "TOut";
 				$ber = "??%";
 			}


### PR DESCRIPTION
Hi,

as seen in Issue #117 "TX Duration continues to increment even though DMR TX has stopped." the dashboard isn't able to recognize timed out DMR calls. So the TX timer in the dashboard is counting tx time to infinity.

My change adds detection of those timed out DMR calls, because they are creating a line like this in the logfile:

`M: 2020-09-25 17:00:33.659 DMR Slot 2, network watchdog has expired`

Now those calls are showed in the dashboard with "TOut" in the "Dur" column when the log message appears.

73s de Thomas, DG0OFZ