### PR TITLE
Update configure.php

### DIFF
--- a/admin/configure.php
+++ b/admin/configure.php
@@ -1117,7 +1117,8 @@ if ($_SERVER["PHP_SELF"] == "/admin/configure.php") {
 	  $configmmdvm['DMR Network']['Address'] = $dmrMasterHostArr[0];
 	  $configmmdvm['DMR Network']['Password'] = '"'.$dmrMasterHostArr[1].'"';
 	  $configmmdvm['DMR Network']['Port'] = $dmrMasterHostArr[2];
-	  if (isset($_POST['bmHSSecurity'])) {
+ 	
+	if ((isset($_POST['bmHSSecurity'])) && substr($dmrMasterHostArr[3], 0, 2) == "BM") {
 		  if (empty($_POST['bmHSSecurity']) != TRUE ) {
 			  $configModem['BrandMeister']['Password'] = '"'.$_POST['bmHSSecurity'].'"';
 			  if ($dmrMasterHostArr[0] != '127.0.0.1') { $configmmdvm['DMR Network']['Password'] = '"'.$_POST['bmHSSecurity'].'"'; }


### PR DESCRIPTION
Added additional code to make sure that BM is in use before setting BM HS Security Code. Resetting to another Master Server from BM Fails on the first attempt as the BM Security code is still set. Hitting apply changes a second time clears the BM Code or deleting it before hitting apply changes the first time will also work
This change clears the code on the first application of apply changes after BM is no longer the selected master server