### PR TITLE
Allow custom URL for Lookup Service

### DIFF
--- a/mmdvmhost/lh.php
+++ b/mmdvmhost/lh.php
@@ -18,13 +18,11 @@ if (file_exists('/etc/pistar-css.ini')) {
     $callsignLookupSvc = "RadioID";
 }
 
-// Safety net
-if (($callsignLookupSvc != "RadioID") && ($callsignLookupSvc != "QRZ")) { $callsignLookupSvc = "RadioID"; }
-
 // Setup the URL(s)
 $idLookupUrl = "https://database.radioid.net/database/view?id=";
-if ($callsignLookupSvc == "RadioID") { $callsignLookupUrl = "https://database.radioid.net/database/view?callsign="; }
+$callsignLookupUrl = "https://database.radioid.net/database/view?callsign=";
 if ($callsignLookupSvc == "QRZ") { $callsignLookupUrl = "https://www.qrz.com/db/"; }
+if (substr($callsignLookupSvc, 0, 4) === "http") { $callsignLookupUrl = $callsignLookupSvc; }
 
 ?>
 <b><?php echo $lang['last_heard_list'];?></b>


### PR DESCRIPTION
This would allow someone to enter an alternate url if desired. If the field does not contain "QRZ" or a URL starting with "http" the RadioID lookup would be used.

I tested this change locally and was able to:
- save a URL correctly in CSS config and have the url successfully generated in call log with the callsign appended
- remove the customers URL and have the correct RadioID link set
- set QRZ and have the orz link set