### PR TITLE
Integration with Hearham.live call sign listener

### DIFF
--- a/admin/configure.php
+++ b/admin/configure.php
@@ -1359,6 +1359,10 @@ if ($_SERVER["PHP_SELF"] == "/admin/configure.php") {
 	if (empty($_POST['dstarNetHangTime']) != TRUE ) {
 	  $configmmdvm['D-Star Network']['ModeHang'] = preg_replace('/[^0-9]/', '', $_POST['dstarNetHangTime']);
 	}
+	if (empty($_POST['HearhamKey']) != TRUE ) {
+	    $configmmdvm['Hearham']['Secret'] = $_POST['HearhamKey'];
+	}
+	
 	// Set YSF Hang Timers
 	if (empty($_POST['ysfRfHangTime']) != TRUE ) {
 	  $configmmdvm['System Fusion']['ModeHang'] = preg_replace('/[^0-9]/', '', $_POST['ysfRfHangTime']);
@@ -3684,6 +3688,18 @@ else:
     <td align="left"><a class="tooltip2" href="#"><?php echo $lang['mode_hangtime'];?>:<span><b>Net Hang Time</b>Stay in the last mode for this many seconds</span></a></td>
     <td align="left" colspan="2"><input type="text" name="hangTime" size="13" maxlength="3" value="<?php echo $configmmdvm['General']['RFModeHang']; ?>" /> in seconds (90 secs works well for Multi-Mode)</td>
     </tr>-->
+    <tr>
+    <td align="left"><a class="tooltip2" href="#">Your Hearham key:<span><b>Hearham "Upload Secret" from hearham.live/setup:</b>Enter your station's secret key</span></a></td>
+    <?php
+	if ( isset($configmmdvm['Hearham']) ) {
+		echo "<td colspan=2 align=\"left\"><input type=\"text\" name=\"HearhamKey\" value=\"".$configmmdvm['Hearham']['Secret']."\" /></td>\n";
+		}
+	else {
+		echo "<td colspan=2 align=\"left\"><input type=\"text\" name=\"HearhamKey\" value=\"\" /></td>\n";
+	}
+    ?>
+    </tr>
+    
     </table>
 	<div><input type="button" value="<?php echo $lang['apply'];?>" onclick="submitform()" /><br /><br /></div>
     <?php } ?>

--- a/mmdvmhost/reportheard.php
+++ b/mmdvmhost/reportheard.php
@@ -7,7 +7,7 @@ require_once $dir.'/config/config.php';          // MMDVMDash Config
 include_once $dir.'/mmdvmhost/tools.php';        // MMDVMDash Tools
 require_once $dir.'/mmdvmhost/functions.php';    // MMDVMDash Functions
 include_once $dir.'/config/language.php';	      // Translation Code
-for($i=0; $i<60; $i+=5) {
+for($t=0; $t<60; $t+=5) {
 
     // Check if the config file exists
     if (file_exists('/etc/pistar-css.ini')) {

--- a/mmdvmhost/reportheard.php
+++ b/mmdvmhost/reportheard.php
@@ -1,12 +1,22 @@
 <?php
-// THIS IS YOUR hearham.live station key:
-$UPLOADKEY = 'YOURHEARHAMKEY';
-
 $dir = dirname(__DIR__);
 require_once $dir.'/config/config.php';          // MMDVMDash Config
 include_once $dir.'/mmdvmhost/tools.php';        // MMDVMDash Tools
 require_once $dir.'/mmdvmhost/functions.php';    // MMDVMDash Functions
 include_once $dir.'/config/language.php';	      // Translation Code
+
+$mmdvmConfigFile = '/etc/mmdvmhost';
+$configmmdvm = parse_ini_file($mmdvmConfigFile, true);
+if( isset($configmmdvm['Hearham'] ) ) {
+	// THIS IS YOUR hearham.live station key:
+	$secret = $configmmdvm['Hearham']['Secret'];
+	//echo "\n";
+	//echo $secret;
+	$UPLOADKEY = $secret;
+} else {
+	exit;
+}
+
 for($t=0; $t<60; $t+=5) {
 
     // Check if the config file exists

--- a/mmdvmhost/reportheard.php
+++ b/mmdvmhost/reportheard.php
@@ -1,0 +1,54 @@
+<?php
+// THIS IS YOUR hearham.live station key:
+$UPLOADKEY = 'YOURHEARHAMKEY';
+
+$dir = dirname(__DIR__);
+require_once $dir.'/config/config.php';          // MMDVMDash Config
+include_once $dir.'/mmdvmhost/tools.php';        // MMDVMDash Tools
+require_once $dir.'/mmdvmhost/functions.php';    // MMDVMDash Functions
+include_once $dir.'/config/language.php';	      // Translation Code
+for($i=0; $i<60; $i+=5) {
+
+    // Check if the config file exists
+    if (file_exists('/etc/pistar-css.ini')) {
+	// Use the values from the file
+	$piStarCssFile = '/etc/pistar-css.ini';
+	if (fopen($piStarCssFile,'r')) { $piStarCss = parse_ini_file($piStarCssFile, true); }
+
+	// Set the Values from the config file
+	if (isset($piStarCss['Lookup']['Service'])) { $callsignLookupSvc = $piStarCss['Lookup']['Service']; }		// Lookup Service "QRZ" or "RadioID"
+	else { $callsignLookupSvc = "RadioID"; }										// Set the default if its missing										// Set the default if its missing
+    } else {
+	// Default values
+	$callsignLookupSvc = "RadioID";
+    }
+
+    $nowUTC = strtotime(gmdate("Y-m-d H:i:s"));
+
+    $i = 0;
+    for ($i = 0;  ($i <= 19); $i++) { //Last 20 calls
+	    if (isset($lastHeard[$i])) {
+		    $listElem = $lastHeard[$i];
+		    if ($listElem[5] == "RF"){
+			    $date = strtotime($listElem[0]);
+			    $type = $listElem[1];
+			    $call = $listElem[2];
+			    echo $nowUTC - $date;
+			    echo 'seconds ago heard '.$call."\n";
+			    if(  $nowUTC - $date < 6 ) {
+				    system("curl -X POST -F 'key=$UPLOADKEY' -F 'hear=$call' https://hearham.com/api/audioDigitalLog");
+			    }
+		    }else{
+		    //Not rf
+		    }
+	    }
+    }
+
+    sleep(5);
+    //Re grab as in functions.php:
+    $logLinesMMDVM = getMMDVMLog();
+    $reverseLogLinesMMDVM = $logLinesMMDVM;
+    array_multisort($reverseLogLinesMMDVM,SORT_DESC);
+    $lastHeard = getLastHeard($reverseLogLinesMMDVM);
+
+}


### PR DESCRIPTION
[Hearham.live](https://hearham.com/) is the free callsign listener for DMR. It works for Brandmeister and Freedmr, TGIF networks in general, but this adds the ability to specifically add a listener to your hotspot, whichever setting it is set to.

To get it working, one must first go to https://hearham.com/setup
get the configuration key which will be put in the dashboard setting here.

With this modified dashboard code, set the Hearham upload key of your channel in the dashboard web interface, then at the terminal:

```
rpi-rw
sudo nano /etc/crontab
```

Add to the bottom of the file:
```
* *     * * *   root    php /var/www/dashboard/mmdvmhost/reportheard.php
```

and this will be called regularly, sending a text message to anyone who doesn't have their radio turned on - let them know their friend is on the radio :)
