### PR TITLE
Screen-reader accessible modes and networks status overview

### DIFF
--- a/css/pistar-css-mini.php
+++ b/css/pistar-css-mini.php
@@ -405,3 +405,40 @@ input.toggle-round-flat:checked + label:after {
         -moz-border-radius : 3px 3px 3px 3px;
     }
 }
+
+/* Tooltip container */
+.hasTooltip {
+    position: relative;
+    display: inline-block;
+}
+
+/* Tooltip text */
+.hasTooltip .tooltipText {
+    visibility: hidden;
+    width: 120px;
+    text-align: center;
+    padding: 5px 0;
+    border-radius: 6px;
+    position: absolute;
+    z-index: 1;
+}
+
+/* Show the tooltip text when you mouse over the tooltip container */
+.hasTooltip:hover .tooltipText {
+    visibility: visible;
+}
+
+/* Screenreader-only */
+.sr-only {
+    border: 0 !important;
+    clip: rect(1px, 1px, 1px, 1px) !important; /* 1 */
+    -webkit-clip-path: inset(50%) !important;
+        clip-path: inset(50%) !important;  /* 2 */
+    height: 1px !important;
+    margin: -1px !important;
+    overflow: hidden !important;
+    padding: 0 !important;
+    position: absolute !important;
+    width: 1px !important;
+    white-space: nowrap !important;            /* 3 */
+}

--- a/css/pistar-css.php
+++ b/css/pistar-css.php
@@ -423,3 +423,40 @@ input.toggle-round-flat:checked + label:after {
     content: "[ ]";
 }
 */
+
+/* Tooltip container */
+.hasTooltip {
+    position: relative;
+    display: inline-block;
+}
+
+/* Tooltip text */
+.hasTooltip .tooltipText {
+    visibility: hidden;
+    width: 120px;
+    text-align: center;
+    padding: 5px 0;
+    border-radius: 6px;
+    position: absolute;
+    z-index: 1;
+}
+
+/* Show the tooltip text when you mouse over the tooltip container */
+.hasTooltip:hover .tooltipText {
+    visibility: visible;
+}
+
+/* Screenreader-only */
+.sr-only {
+    border: 0 !important;
+    clip: rect(1px, 1px, 1px, 1px) !important; /* 1 */
+    -webkit-clip-path: inset(50%) !important;
+        clip-path: inset(50%) !important;  /* 2 */
+    height: 1px !important;
+    margin: -1px !important;
+    overflow: hidden !important;
+    padding: 0 !important;
+    position: absolute !important;
+    width: 1px !important;
+    white-space: nowrap !important;            /* 3 */
+}

--- a/mmdvmhost/functions.php
+++ b/mmdvmhost/functions.php
@@ -104,57 +104,87 @@ function checkDMRLogin ($dmrDaemon) {
 
 function showMode($mode, $mmdvmconfigs) {
 	// shows if mode is enabled or not.
+	// TODO: Consider localiZation
+	$states = array(
+		"ok" => "OK",
+		"stopped" => "Stopped",
+		"error" => "Connection error",
+		"disabled" => "Disabled"
+	);
+
 	if (getEnabled($mode, $mmdvmconfigs) == 1) {
 		if ($mode == "D-Star Network") {
 			if (isProcessRunning("ircddbgatewayd")) {
 				echo "<td style=\"background:#0b0; color:#030; width:50%;\">";
+				$state = "ok";
 			} else {
 				echo "<td style=\"background:#b00; color:#500; width:50%;\">";
+				$state = "stopped";
 			}
 		}
 		elseif ($mode == "System Fusion Network") {
 			if (isProcessRunning("YSFGateway")) {
 				echo "<td style=\"background:#0b0; color:#030; width:50%;\">";
+				$state = "ok";
 			} else {
 				echo "<td style=\"background:#b00; color:#500; width:50%;\">";
+				$state = "stopped";
 			}
 		}
 		elseif ($mode == "P25 Network") {
 			if (isProcessRunning("P25Gateway")) {
 				echo "<td style=\"background:#0b0; color:#030; width:50%;\">";
+				$state = "ok";
 			} else {
 				echo "<td style=\"background:#b00; color:#500; width:50%;\">";
+				$state = "stopped";
 			}
 		}
 		elseif ($mode == "NXDN Network") {
 			if (isProcessRunning("NXDNGateway")) {
 				echo "<td style=\"background:#0b0; color:#030; width:50%;\">";
+				$state = "ok";
 			} else {
 				echo "<td style=\"background:#b00; color:#500; width:50%;\">";
+				$state = "stopped";
 			}
 		}
 		elseif ($mode == "DAPNET Network") {
 			if (isProcessRunning("DAPNETGateway")) {
 				echo "<td style=\"background:#0b0; color:#030; width:50%;\">";
+				$state = "ok";
 			} else {
 				echo "<td style=\"background:#b00; color:#500; width:50%;\">";
+				$state = "stopped";
 			}
 		}
 		elseif ($mode == "DMR Network") {
 			if (getConfigItem("DMR Network", "Address", $mmdvmconfigs) == '127.0.0.1') {
 				if (isProcessRunning("DMRGateway")) {
-					if (checkDMRLogin("DMRGateway") > 0) { echo "<td style=\"background:#ff9; color:#030; width:50%;\">"; }
-					else { echo "<td style=\"background:#0b0; color:#030; width:50%;\">"; }
+					if (checkDMRLogin("DMRGateway") > 0) {
+						echo "<td style=\"background:#ff9; color:#030; width:50%;\">";
+						$state = "error";
+					} else {
+						echo "<td style=\"background:#0b0; color:#030; width:50%;\">";
+						$state = "ok";
+					}
 				} else {
 					echo "<td style=\"background:#b00; color:#500; width:50%;\">";
+					$state = "stopped";
 				}
 			}
 			else {
 				if (isProcessRunning("MMDVMHost")) {
-					if (checkDMRLogin("MMDVMHost") > 0) { echo "<td style=\"background:#ff9; color:#030; width:50%;\">"; }
-					else { echo "<td style=\"background:#0b0; color:#030; width:50%;\">"; }
+					if (checkDMRLogin("MMDVMHost") > 0) {
+						echo "<td style=\"background:#ff9; color:#030; width:50%;\">";
+						$state = "error";
+					} else {
+						echo "<td style=\"background:#0b0; color:#030; width:50%;\">";
+						$state = "ok";
+					}
 				} else {
 					echo "<td style=\"background:#b00; color:#500; width:50%;\">";
+					$state = "stopped";
 				}
 			}
 		}
@@ -162,8 +192,10 @@ function showMode($mode, $mmdvmconfigs) {
 			if ($mode == "D-Star" || $mode == "DMR" || $mode == "System Fusion" || $mode == "P25" || $mode == "NXDN" || $mode == "POCSAG") {
 				if (isProcessRunning("MMDVMHost")) {
 					echo "<td style=\"background:#0b0; color:#030; width:50%;\">";
+					$state = "ok";
 				} else {
 					echo "<td style=\"background:#b00; color:#500; width:50%;\">";
+					$state = "stopped";
 				}
 			}
 		}
@@ -171,60 +203,78 @@ function showMode($mode, $mmdvmconfigs) {
 	elseif ( ($mode == "YSF XMode") && (getEnabled("System Fusion", $mmdvmconfigs) == 1) ) {
 		if ( (isProcessRunning("MMDVMHost")) && (isProcessRunning("YSF2DMR") || isProcessRunning("YSF2NXDN") || isProcessRunning("YSF2P25")) ) {
 			echo "<td style=\"background:#0b0; color:#030; width:50%;\">";
+			$state = "ok";
 		} else {
-			echo "<td style=\"background:#606060; color:#b0b0b0;\" aria-disabled=\"true>\">";
+			echo "<td style=\"background:#606060; color:#b0b0b0;\" aria-disabled=\"true\">";
+			$state = "disabled";
 		}
 	}
 	elseif ( ($mode == "DMR XMode") && (getEnabled("DMR", $mmdvmconfigs) == 1) ) {
 		if ( (isProcessRunning("MMDVMHost")) && (isProcessRunning("DMR2YSF") || isProcessRunning("DMR2NXDN")) ) {
 			echo "<td style=\"background:#0b0; color:#030; width:50%;\">";
+			$state = "ok";
 		} else {
-			echo "<td style=\"background:#606060; color:#b0b0b0;\" aria-disabled=\"true>\">";
+			echo "<td style=\"background:#606060; color:#b0b0b0;\" aria-disabled=\"true\">";
+			$state = "disabled";
 		}
 	}
 	elseif ( ($mode == "YSF2DMR Network") && (getEnabled("System Fusion", $mmdvmconfigs) == 1) ) {
 		if (isProcessRunning("YSF2DMR")) {
 			echo "<td style=\"background:#0b0; color:#030; width:50%;\">";
+			$state = "ok";
 		} else {
-			echo "<td style=\"background:#606060; color:#b0b0b0;\" aria-disabled=\"true>\">";
+			echo "<td style=\"background:#606060; color:#b0b0b0;\" aria-disabled=\"true\">";
+			$state = "disabled";
 		}
 	}
 	elseif ( ($mode == "YSF2NXDN Network") && (getEnabled("System Fusion", $mmdvmconfigs) == 1) ) {
 		if (isProcessRunning("YSF2NXDN")) {
 			echo "<td style=\"background:#0b0; color:#030; width:50%;\">";
+			$state = "ok";
 		} else {
-			echo "<td style=\"background:#606060; color:#b0b0b0;\" aria-disabled=\"true>\">";
+			echo "<td style=\"background:#606060; color:#b0b0b0;\" aria-disabled=\"true\">";
+			$state = "disabled";
 		}
 	}
 	elseif ( ($mode == "YSF2P25 Network") && (getEnabled("System Fusion", $mmdvmconfigs) == 1) ) {
 		if (isProcessRunning("YSF2P25")) {
 			echo "<td style=\"background:#0b0; color:#030; width:50%;\">";
+			$state = "ok";
 		} else {
-			echo "<td style=\"background:#606060; color:#b0b0b0;\" aria-disabled=\"true>\">";
+			echo "<td style=\"background:#606060; color:#b0b0b0;\" aria-disabled=\"true\">";
+			$state = "disabled";
 		}
 	}
 	elseif ( ($mode == "DMR2NXDN Network") && (getEnabled("DMR", $mmdvmconfigs) == 1) ) {
 		if (isProcessRunning("DMR2NXDN")) {
 			echo "<td style=\"background:#0b0; color:#030; width:50%;\">";
+			$state = "ok";
 		} else {
-			echo "<td style=\"background:#606060; color:#b0b0b0;\" aria-disabled=\"true>\">";
+			echo "<td style=\"background:#606060; color:#b0b0b0;\" aria-disabled=\"true\">";
+			$state = "disabled";
 		}
 	}
 	elseif ( ($mode == "DMR2YSF Network") && (getEnabled("DMR", $mmdvmconfigs) == 1) ) {
 		if (isProcessRunning("DMR2YSF")) {
 			echo "<td style=\"background:#0b0; color:#030; width:50%;\">";
+			$state = "ok";
 		} else {
-			echo "<td style=\"background:#606060; color:#b0b0b0;\" aria-disabled=\"true>\">";
+			echo "<td style=\"background:#606060; color:#b0b0b0;\" aria-disabled=\"true\">";
+			$state = "disabled";
 		}
 	}
 	else {
-		echo "<td style=\"background:#606060; color:#b0b0b0;\" aria-disabled=\"true>\">";
+		echo "<td style=\"background:#606060; color:#b0b0b0;\" aria-disabled=\"true\">";
+		$state = "disabled";
     }
     $mode = str_replace("System Fusion", "YSF", $mode);
     $mode = str_replace("Network", "Net", $mode);
     if (strpos($mode, 'YSF2') > -1) { $mode = str_replace(" Net", "", $mode); }
     if (strpos($mode, 'DMR2') > -1) { $mode = str_replace(" Net", "", $mode); }
-    echo $mode."</td>\n";
+    echo '<div class="hasTooltip">' . $mode;
+    echo '<span class="sr-only">: ' . $states[$state] . "</span>";
+    echo '<span class="tooltipText">' . $states[$state] . "</span>";
+    echo "</div></td>\n";
 }
 
 function getMMDVMLog() {


### PR DESCRIPTION
Resolve #144 by:
* Adding sr-only css style for text visible by screen-readers only
* Preparing hasTooltip and tooltipText css styles
* Adding a table of verbal status interpretations (mmdvmhost/functions.php:showMode)
* The verbal interpretation is showed to screen-reader users and as a tooltip on hovering mouse over the mode/network

Please adjust the tooltip position as needed. See: https://www.w3schools.com/css/css_tooltip.asp