### PR TITLE
Fix P25Gateway log parsing issues

### DIFF
--- a/mmdvmhost/functions.php
+++ b/mmdvmhost/functions.php
@@ -279,13 +279,13 @@ function getP25GatewayLog() {
 	$logLines2 = array();
         if (file_exists(P25GATEWAYLOGPATH."/".P25GATEWAYLOGPREFIX."-".gmdate("Y-m-d").".log")) {
 		$logPath1 = P25GATEWAYLOGPATH."/".P25GATEWAYLOGPREFIX."-".gmdate("Y-m-d").".log";
-		$logLines1 = preg_split('/\r\n|\r|\n/', `egrep -h "ink|Starting|witched" $logPath1 | cut -d" " -f2- | tail -1`);
+		$logLines1 = preg_split('/\r\n|\r|\n/', `egrep -h "^M.*(ink|Starting|witched)" $logPath1 | cut -d" " -f2- | tail -1`);
         }
 	$logLines1 = array_filter($logLines1);
         if (sizeof($logLines1) == 0) {
                 if (file_exists(P25GATEWAYLOGPATH."/".P25GATEWAYLOGPREFIX."-".gmdate("Y-m-d", time() - 86340).".log")) {
                         $logPath2 = P25GATEWAYLOGPATH."/".P25GATEWAYLOGPREFIX."-".gmdate("Y-m-d", time() - 86340).".log";
-			$logLines2 = preg_split('/\r\n|\r|\n/', `egrep -h "ink|Starting|witched" $logPath2 | cut -d" " -f2- | tail -1`);
+			$logLines2 = preg_split('/\r\n|\r|\n/', `egrep -h "^M.*(ink|Starting|witched)" $logPath2 | cut -d" " -f2- | tail -1`);
                 }
 		$logLines2 = array_filter($logLines2);
         }
@@ -1054,6 +1054,11 @@ function getActualLink($logLines, $mode) {
 		  $to = preg_replace('/[^0-9]/', '', substr($logLine, 55, 5));
 		  $to = preg_replace('/[^0-9]/', '', $to);
 		  return "TG ".$to;
+               }
+               if (strpos($logLine,"Statically linked to reflector")) {
+                  $to = preg_replace('/[^0-9]/', '', substr($logLine, 55, 5));
+                  $to = preg_replace('/[^0-9]/', '', $to);
+                  return "TG ".$to;
                }
 	       if (strpos($logLine,"Switched to reflector")) {
 		  $to = preg_replace('/[^0-9]/', '', substr($logLine, 46, 5));


### PR DESCRIPTION
This PR addresses 2 issues causing the P25 Network status to show Not Linked, when it was actually Linked to a reflector

1. On initial startup, The P25 network would show not connected.  This was caused by a change in format of the P25Gateway log file message generated when connecting on startup.  P25Gateway version 20210606_PS4 now says:

`M: 2022-10-11 00:52:46.588 Statically linked to reflector 10209`

Previous Versions appear to have said 

`2000-01-01 00:00:00.000 Linked at startup to reflector 10100`

Added an additional `if` to handle the new case

2. After running for some period of time, the P25 network would show not connected.  This was caused by error messages for non-resolvable hosts inadvertently matching the regular expressions used in 'getP25GatewayLog()'

Specifically, the host `dagobah.hblink.it` contains the substring `ink`, which matches the regex `"ink|Starting|witched"`

When the system periodically refreshes the P25Hosts file, it causes the names of any unreachable hosts to go in to the log as so:

```
E: 2022-10-11 00:52:19.235 Cannot find address for host p25.superfreqdigital.com
W: 2022-10-11 00:52:19.235 Unable to resolve the address of p25.superfreqdigital.com
E: 2022-10-11 00:52:19.514 Cannot find address for host nz6d.dx40.com
W: 2022-10-11 00:52:19.515 Unable to resolve the address of nz6d.dx40.com
E: 2022-10-11 00:52:19.671 Cannot find address for host hamsomniac.mooo.com
W: 2022-10-11 00:52:19.671 Unable to resolve the address of hamsomniac.mooo.com
E: 2022-10-11 00:52:19.857 Cannot find address for host p25.r1ik.ru
W: 2022-10-11 00:52:19.857 Unable to resolve the address of p25.r1ik.ru
E: 2022-10-11 00:52:19.936 Cannot find address for host p25tn.w4kdg.org
W: 2022-10-11 00:52:19.936 Unable to resolve the address of p25tn.w4kdg.org
E: 2022-10-11 00:52:20.101 Cannot find address for host p25.dmr-peru.pe
W: 2022-10-11 00:52:20.101 Unable to resolve the address of p25.dmr-peru.pe
E: 2022-10-11 00:52:21.511 Cannot find address for host dagobah.hblink.it
W: 2022-10-11 00:52:21.511 Unable to resolve the address of dagobah.hblink.it
E: 2022-10-11 00:52:21.850 Cannot find address for host hamsomniac.mooo.com
W: 2022-10-11 00:52:21.850 Unable to resolve the address of hamsomniac.mooo.com
E: 2022-10-11 00:52:22.091 Cannot find address for host p25.alecwasserman.com
W: 2022-10-11 00:52:22.107 Unable to resolve the address of p25.alecwasserman.com
E: 2022-10-11 00:52:23.343 Cannot find address for host p25-dx1ace.hopto.org
W: 2022-10-11 00:52:23.343 Unable to resolve the address of p25-dx1ace.hopto.org
E: 2022-10-11 00:52:23.522 Cannot find address for host p25.signalseverywhere.com
W: 2022-10-11 00:52:23.522 Unable to resolve the address of p25.signalseverywhere.com
```
Which, if they are the most recent lines in the file, can cause any error messages matching the regex to end up as the line passed to the getAcualLink() function, which cause the P25 Network status to go to Not Linked once the P25Hosts file is refreshed

Fixed by updating the regular expressions to only capture lines starting with "M" (Message?), which removes the Error, Warning, and Info lines

Testing:  This has been running on my personal hotspot for multiple weeks, and accurately reflects status