### PR TITLE
Add support for CSS dark mode

### DIFF
--- a/admin/calibration.php
+++ b/admin/calibration.php
@@ -98,6 +98,7 @@ if ($_SERVER["PHP_SELF"] == "/admin/calibration.php") {
     <meta http-equiv="Expires" content="0" />
     <title>Pi-Star - <?php echo $lang['digital_voice']." ".$lang['dashboard']." - Calibration";?></title>
     <link rel="stylesheet" type="text/css" href="css/pistar-css.php" />
+    <link rel="stylesheet" type="text/css" href="css/pistar-dark.css" />
     <script type="text/javascript" src="/jquery.min.js"></script>
     <script type="text/javascript" src="/jquery-timing.min.js"></script>
     <script type="text/javascript" src="/plotly-basic.min.js"></script>

--- a/admin/config_backup.php
+++ b/admin/config_backup.php
@@ -30,6 +30,7 @@ if ($_SERVER["PHP_SELF"] == "/admin/config_backup.php") {
     <meta http-equiv="Expires" content="0" />
     <title>Pi-Star - <?php echo $lang['digital_voice']." ".$lang['dashboard']." - ".$lang['backup_restore'];?></title>
     <link rel="stylesheet" type="text/css" href="css/pistar-css.php" />
+    <link rel="stylesheet" type="text/css" href="css/pistar-dark.css" />
   </head>
   <body>
   <div class="container">

--- a/admin/configure.php
+++ b/admin/configure.php
@@ -176,7 +176,8 @@ $MYCALL=strtoupper($callsign);
     <meta http-equiv="Expires" content="0" />
     <title><?php echo "$MYCALL"." - ".$lang['digital_voice']." ".$lang['dashboard']." - ".$lang['configuration'];?></title>
     <link rel="stylesheet" type="text/css" href="css/pistar-css.php?version=0.95" />
-    <script type="text/javascript">
+	<link rel="stylesheet" type="text/css" href="css/pistar-dark.css?version=0.95" />
+   <script type="text/javascript">
 	function disablesubmitbuttons() {
 		var inputs = document.getElementsByTagName('input');
 		for (var i = 0; i < inputs.length; i++) {

--- a/admin/expert/edit_dapnetgateway.php
+++ b/admin/expert/edit_dapnetgateway.php
@@ -25,6 +25,7 @@ require_once('../config/version.php');
     <meta http-equiv="Expires" content="0" />
     <title>Pi-Star - Digital Voice Dashboard - Expert Editor</title>
     <link rel="stylesheet" type="text/css" href="../css/pistar-css.php" />
+	<link rel="stylesheet" type="text/css" href="../css/pistar-dark.css" />
   </head>
   <body>
   <div class="container">

--- a/admin/expert/edit_dashboard.php
+++ b/admin/expert/edit_dashboard.php
@@ -25,6 +25,7 @@ require_once('../config/version.php');
     <meta http-equiv="Expires" content="0" />
     <title>Pi-Star - Digital Voice Dashboard - Expert Editor</title>
     <link rel="stylesheet" type="text/css" href="../css/pistar-css.php" />
+    <link rel="stylesheet" type="text/css" href="../css/pistar-dark.css" />
     <script type="text/javascript">
       function factoryReset()
 	{

--- a/admin/expert/edit_dmrgateway.php
+++ b/admin/expert/edit_dmrgateway.php
@@ -25,6 +25,7 @@ require_once('../config/version.php');
     <meta http-equiv="Expires" content="0" />
     <title>Pi-Star - Digital Voice Dashboard - Expert Editor</title>
     <link rel="stylesheet" type="text/css" href="../css/pistar-css.php" />
+    <link rel="stylesheet" type="text/css" href="../css/pistar-dark.css" />
   </head>
   <body>
   <div class="container">

--- a/admin/expert/edit_dstarrepeater.php
+++ b/admin/expert/edit_dstarrepeater.php
@@ -25,6 +25,7 @@ require_once('../config/version.php');
     <meta http-equiv="Expires" content="0" />
     <title>Pi-Star - Digital Voice Dashboard - Expert Editor</title>
     <link rel="stylesheet" type="text/css" href="../css/pistar-css.php" />
+    <link rel="stylesheet" type="text/css" href="../css/pistar-dark.css" />
   </head>
   <body>
   <div class="container">

--- a/admin/expert/edit_ircddbgateway.php
+++ b/admin/expert/edit_ircddbgateway.php
@@ -25,6 +25,7 @@ require_once('../config/version.php');
     <meta http-equiv="Expires" content="0" />
     <title>Pi-Star - Digital Voice Dashboard - Expert Editor</title>
     <link rel="stylesheet" type="text/css" href="../css/pistar-css.php" />
+    <link rel="stylesheet" type="text/css" href="../css/pistar-dark.css" />
   </head>
   <body>
   <div class="container">

--- a/admin/expert/edit_mmdvmhost.php
+++ b/admin/expert/edit_mmdvmhost.php
@@ -25,6 +25,7 @@ require_once('../config/version.php');
     <meta http-equiv="Expires" content="0" />
     <title>Pi-Star - Digital Voice Dashboard - Expert Editor</title>
     <link rel="stylesheet" type="text/css" href="../css/pistar-css.php" />
+    <link rel="stylesheet" type="text/css" href="../css/pistar-dark.css" />
   </head>
   <body>
   <div class="container">

--- a/admin/expert/edit_nxdngateway.php
+++ b/admin/expert/edit_nxdngateway.php
@@ -25,6 +25,7 @@ require_once('../config/version.php');
     <meta http-equiv="Expires" content="0" />
     <title>Pi-Star - Digital Voice Dashboard - Expert Editor</title>
     <link rel="stylesheet" type="text/css" href="../css/pistar-css.php" />
+    <link rel="stylesheet" type="text/css" href="../css/pistar-dark.css" />
   </head>
   <body>
   <div class="container">

--- a/admin/expert/edit_p25gateway.php
+++ b/admin/expert/edit_p25gateway.php
@@ -25,6 +25,7 @@ require_once('../config/version.php');
     <meta http-equiv="Expires" content="0" />
     <title>Pi-Star - Digital Voice Dashboard - Expert Editor</title>
     <link rel="stylesheet" type="text/css" href="../css/pistar-css.php" />
+    <link rel="stylesheet" type="text/css" href="../css/pistar-dark.css" />
   </head>
   <body>
   <div class="container">

--- a/admin/expert/edit_starnetserver.php
+++ b/admin/expert/edit_starnetserver.php
@@ -25,6 +25,7 @@ require_once('../config/version.php');
     <meta http-equiv="Expires" content="0" />
     <title>Pi-Star - Digital Voice Dashboard - Expert Editor</title>
     <link rel="stylesheet" type="text/css" href="../css/pistar-css.php" />
+    <link rel="stylesheet" type="text/css" href="../css/pistar-dark.css" />
   </head>
   <body>
   <div class="container">

--- a/admin/expert/edit_timeserver.php
+++ b/admin/expert/edit_timeserver.php
@@ -25,6 +25,7 @@ require_once('../config/version.php');
     <meta http-equiv="Expires" content="0" />
     <title>Pi-Star - Digital Voice Dashboard - Expert Editor</title>
     <link rel="stylesheet" type="text/css" href="../css/pistar-css.php" />
+    <link rel="stylesheet" type="text/css" href="../css/pistar-dark.css" />
   </head>
   <body>
   <div class="container">

--- a/admin/expert/edit_ysfgateway.php
+++ b/admin/expert/edit_ysfgateway.php
@@ -25,6 +25,7 @@ require_once('../config/version.php');
     <meta http-equiv="Expires" content="0" />
     <title>Pi-Star - Digital Voice Dashboard - Expert Editor</title>
     <link rel="stylesheet" type="text/css" href="../css/pistar-css.php" />
+    <link rel="stylesheet" type="text/css" href="../css/pistar-dark.css" />
   </head>
   <body>
   <div class="container">

--- a/admin/expert/fulledit_bmapikey.php
+++ b/admin/expert/fulledit_bmapikey.php
@@ -25,6 +25,7 @@ require_once('../config/version.php');
     <meta http-equiv="Expires" content="0" />
     <title>Pi-Star - Digital Voice Dashboard - Expert Editor</title>
     <link rel="stylesheet" type="text/css" href="../css/pistar-css.php" />
+    <link rel="stylesheet" type="text/css" href="../css/pistar-dark.css" />
   </head>
   <body>
   <div class="container">

--- a/admin/expert/fulledit_cron.php
+++ b/admin/expert/fulledit_cron.php
@@ -25,6 +25,7 @@ require_once('../config/version.php');
     <meta http-equiv="Expires" content="0" />
     <title>Pi-Star - Digital Voice Dashboard - Expert Editor</title>
     <link rel="stylesheet" type="text/css" href="../css/pistar-css.php" />
+    <link rel="stylesheet" type="text/css" href="../css/pistar-dark.css" />
   </head>
   <body>
   <div class="container">

--- a/admin/expert/fulledit_dapnetapi.php
+++ b/admin/expert/fulledit_dapnetapi.php
@@ -25,6 +25,7 @@ require_once('../config/version.php');
     <meta http-equiv="Expires" content="0" />
     <title>Pi-Star - Digital Voice Dashboard - Expert Editor</title>
     <link rel="stylesheet" type="text/css" href="../css/pistar-css.php" />
+    <link rel="stylesheet" type="text/css" href="../css/pistar-dark.css" />
   </head>
   <body>
   <div class="container">

--- a/admin/expert/fulledit_dmrgateway.php
+++ b/admin/expert/fulledit_dmrgateway.php
@@ -25,6 +25,7 @@ require_once('../config/version.php');
     <meta http-equiv="Expires" content="0" />
     <title>Pi-Star - Digital Voice Dashboard - Expert Editor</title>
     <link rel="stylesheet" type="text/css" href="../css/pistar-css.php" />
+    <link rel="stylesheet" type="text/css" href="../css/pistar-dark.css" />
   </head>
   <body>
   <div class="container">

--- a/admin/expert/fulledit_pistar-remote.php
+++ b/admin/expert/fulledit_pistar-remote.php
@@ -25,6 +25,7 @@ require_once('../config/version.php');
     <meta http-equiv="Expires" content="0" />
     <title>Pi-Star - Digital Voice Dashboard - Expert Editor</title>
     <link rel="stylesheet" type="text/css" href="../css/pistar-css.php" />
+    <link rel="stylesheet" type="text/css" href="../css/pistar-dark.css" />
   </head>
   <body>
   <div class="container">

--- a/admin/expert/fulledit_rssidat.php
+++ b/admin/expert/fulledit_rssidat.php
@@ -25,6 +25,7 @@ require_once('../config/version.php');
     <meta http-equiv="Expires" content="0" />
     <title>Pi-Star - Digital Voice Dashboard - Expert Editor</title>
     <link rel="stylesheet" type="text/css" href="../css/pistar-css.php" />
+    <link rel="stylesheet" type="text/css" href="../css/pistar-dark.css" />
   </head>
   <body>
   <div class="container">

--- a/admin/expert/fulledit_wpaconfig.php
+++ b/admin/expert/fulledit_wpaconfig.php
@@ -25,6 +25,7 @@ require_once('../config/version.php');
     <meta http-equiv="Expires" content="0" />
     <title>Pi-Star - Digital Voice Dashboard - Expert Editor</title>
     <link rel="stylesheet" type="text/css" href="../css/pistar-css.php" />
+    <link rel="stylesheet" type="text/css" href="../css/pistar-dark.css" />
   </head>
   <body>
   <div class="container">

--- a/admin/expert/index.php
+++ b/admin/expert/index.php
@@ -25,6 +25,7 @@ require_once('../config/version.php');
     <meta http-equiv="Expires" content="0" />
     <title>Pi-Star - Digital Voice Dashboard - Expert Editor</title>
     <link rel="stylesheet" type="text/css" href="../css/pistar-css.php" />
+    <link rel="stylesheet" type="text/css" href="../css/pistar-dark.css" />
   </head>
   <body>
   <div class="container">

--- a/admin/expert/jitter_test.php
+++ b/admin/expert/jitter_test.php
@@ -76,6 +76,7 @@ if ($_SERVER["PHP_SELF"] == "/admin/expert/jitter_test.php") {
     <meta http-equiv="Expires" content="0" />
     <title>Pi-Star - <?php echo $lang['digital_voice']." ".$lang['dashboard']." - ".$lang['update'];?></title>
     <link rel="stylesheet" type="text/css" href="../css/pistar-css.php" />
+    <link rel="stylesheet" type="text/css" href="../css/pistar-dark.css" />
     <script type="text/javascript" src="/jquery.min.js"></script>
     <script type="text/javascript" src="/jquery-timing.min.js"></script>
     <script type="text/javascript">

--- a/admin/expert/ssh_access.php
+++ b/admin/expert/ssh_access.php
@@ -33,6 +33,7 @@ if ($_SERVER["PHP_SELF"] == "/admin/expert/ssh_access.php") {
     <meta http-equiv="Expires" content="0" />
     <title>Pi-Star - <?php echo $lang['digital_voice']." ".$lang['dashboard']." - SSH";?></title>
     <link rel="stylesheet" type="text/css" href="../css/pistar-css.php" />
+    <link rel="stylesheet" type="text/css" href="../css/pistar-dark.css" />
     <script type="text/javascript" src="/jquery.min.js"></script>
     <script type="text/javascript" src="/jquery-timing.min.js"></script>
   </head>

--- a/admin/expert/upgrade.php
+++ b/admin/expert/upgrade.php
@@ -70,6 +70,7 @@ if ($_SERVER["PHP_SELF"] == "/admin/expert/upgrade.php") {
     <meta http-equiv="Expires" content="0" />
     <title>Pi-Star - <?php echo $lang['digital_voice']." ".$lang['dashboard']." - ".$lang['update'];?></title>
     <link rel="stylesheet" type="text/css" href="../css/pistar-css.php" />
+    <link rel="stylesheet" type="text/css" href="../css/pistar-dark.css" />
     <script type="text/javascript" src="/jquery.min.js"></script>
     <script type="text/javascript" src="/jquery-timing.min.js"></script>
     <script type="text/javascript">

--- a/admin/live_modem_log.php
+++ b/admin/live_modem_log.php
@@ -68,6 +68,7 @@ if ($_SERVER["PHP_SELF"] == "/admin/live_modem_log.php") {
     <meta http-equiv="Expires" content="0" />
     <title>Pi-Star - <?php echo $lang['digital_voice']." ".$lang['dashboard']." - ".$lang['live_logs'];?></title>
     <link rel="stylesheet" type="text/css" href="css/pistar-css.php" />
+    <link rel="stylesheet" type="text/css" href="css/pistar-dark.css" />
     <script type="text/javascript" src="/jquery.min.js"></script>
     <script type="text/javascript" src="/jquery-timing.min.js"></script>
     <script type="text/javascript">

--- a/admin/power.php
+++ b/admin/power.php
@@ -31,6 +31,7 @@ if ($_SERVER["PHP_SELF"] == "/admin/power.php") {
     <meta http-equiv="Expires" content="0" />
     <title>Pi-Star - <?php echo $lang['digital_voice']." ".$lang['dashboard']." - ".$lang['power'];?></title>
     <link rel="stylesheet" type="text/css" href="css/pistar-css.php" />
+    <link rel="stylesheet" type="text/css" href="css/pistar-dark.css" />
   </head>
   <body>
   <div class="container">

--- a/admin/sysinfo.php
+++ b/admin/sysinfo.php
@@ -91,6 +91,7 @@ function formatSize( $bytes ) {
     <meta http-equiv="Expires" content="0" />
     <title>Pi-Star - <?php echo $lang['digital_voice']." ".$lang['dashboard']." - ".$lang['update'];?></title>
     <link rel="stylesheet" type="text/css" href="css/pistar-css.php" />
+    <link rel="stylesheet" type="text/css" href="css/pistar-dark.css" />
     <script type="text/javascript" src="/jquery.min.js"></script>
     <script type="text/javascript" src="/jquery-timing.min.js"></script>
     <style>  

--- a/admin/update.php
+++ b/admin/update.php
@@ -78,6 +78,7 @@ if ($_SERVER["PHP_SELF"] == "/admin/update.php") {
     <meta http-equiv="Expires" content="0" />
     <title>Pi-Star - <?php echo $lang['digital_voice']." ".$lang['dashboard']." - ".$lang['update'];?></title>
     <link rel="stylesheet" type="text/css" href="css/pistar-css.php" />
+    <link rel="stylesheet" type="text/css" href="css/pistar-dark.css" />
     <script type="text/javascript" src="/jquery.min.js"></script>
     <script type="text/javascript" src="/jquery-timing.min.js"></script>
     <script type="text/javascript">

--- a/admin/wifi.php
+++ b/admin/wifi.php
@@ -17,6 +17,7 @@ echo '<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
 <link rel="shortcut icon" href="images/favicon.ico" type="image/x-icon" />
 <meta http-equiv="Expires" content="0" />
 <link rel="stylesheet" type="text/css" href="css/pistar-css.php" />
+<link rel="stylesheet" type="text/css" href="css/pistar-dark.css" />
 <link rel="stylesheet" type="text/css" href="wifi/styles.php" />
 <script type="text/Javascript" src="wifi/functions.js?version=1.6"></script>
 <title>Pi-Star - Digital Voice Dashboard - WiFi Config</title>

--- a/config/browserdetect.php
+++ b/config/browserdetect.php
@@ -2,14 +2,17 @@
 if(empty($_SERVER['HTTP_USER_AGENT'])) {
   print "    <link rel=\"stylesheet\" type=\"text/css\" media=\"screen and (min-width: 830px)\" href=\"css/pistar-css.php?version=0.95\" />\n";
   print "    <link rel=\"stylesheet\" type=\"text/css\" media=\"screen and (max-width: 829px)\" href=\"css/pistar-css-mini.php?version=0.95\" />\n";
+  print "    <link rel=\"stylesheet\" type=\"text/css\" media=\"(prefers-color-scheme: dark)\" href=\"css/pistar-dark.css?version=0.95\" />\n";
 } else {
   $useragent=$_SERVER['HTTP_USER_AGENT'];
   if (preg_match('/(android|bb\d+|meego).+mobile|avantgo|bada\/|blackberry|blazer|compal|elaine|fennec|hiptop|iemobile|ip(hone|od)|iris|kindle|lge |maemo|midp|mmp|mobile.+firefox|netfront|opera m(ob|in)i|palm( os)?|phone|p(ixi|re)\/|plucker|pocket|psp|series(4|6)0|symbian|treo|up\.(browser|link)|vodafone|wap|windows ce|xda|xiino/i',$useragent)||preg_match('/1207|6310|6590|3gso|4thp|50[1-6]i|770s|802s|a wa|abac|ac(er|oo|s\-)|ai(ko|rn)|al(av|ca|co)|amoi|an(ex|ny|yw)|aptu|ar(ch|go)|as(te|us)|attw|au(di|\-m|r |s )|avan|be(ck|ll|nq)|bi(lb|rd)|bl(ac|az)|br(e|v)w|bumb|bw\-(n|u)|c55\/|capi|ccwa|cdm\-|cell|chtm|cldc|cmd\-|co(mp|nd)|craw|da(it|ll|ng)|dbte|dc\-s|devi|dica|dmob|do(c|p)o|ds(12|\-d)|el(49|ai)|em(l2|ul)|er(ic|k0)|esl8|ez([4-7]0|os|wa|ze)|fetc|fly(\-|_)|g1 u|g560|gene|gf\-5|g\-mo|go(\.w|od)|gr(ad|un)|haie|hcit|hd\-(m|p|t)|hei\-|hi(pt|ta)|hp( i|ip)|hs\-c|ht(c(\-| |_|a|g|p|s|t)|tp)|hu(aw|tc)|i\-(20|go|ma)|i230|iac( |\-|\/)|ibro|idea|ig01|ikom|im1k|inno|ipaq|iris|ja(t|v)a|jbro|jemu|jigs|kddi|keji|kgt( |\/)|klon|kpt |kwc\-|kyo(c|k)|le(no|xi)|lg( g|\/(k|l|u)|50|54|\-[a-w])|libw|lynx|m1\-w|m3ga|m50\/|ma(te|ui|xo)|mc(01|21|ca)|m\-cr|me(rc|ri)|mi(o8|oa|ts)|mmef|mo(01|02|bi|de|do|t(\-| |o|v)|zz)|mt(50|p1|v )|mwbp|mywa|n10[0-2]|n20[2-3]|n30(0|2)|n50(0|2|5)|n7(0(0|1)|10)|ne((c|m)\-|on|tf|wf|wg|wt)|nok(6|i)|nzph|o2im|op(ti|wv)|oran|owg1|p800|pan(a|d|t)|pdxg|pg(13|\-([1-8]|c))|phil|pire|pl(ay|uc)|pn\-2|po(ck|rt|se)|prox|psio|pt\-g|qa\-a|qc(07|12|21|32|60|\-[2-7]|i\-)|qtek|r380|r600|raks|rim9|ro(ve|zo)|s55\/|sa(ge|ma|mm|ms|ny|va)|sc(01|h\-|oo|p\-)|sdk\/|se(c(\-|0|1)|47|mc|nd|ri)|sgh\-|shar|sie(\-|m)|sk\-0|sl(45|id)|sm(al|ar|b3|it|t5)|so(ft|ny)|sp(01|h\-|v\-|v )|sy(01|mb)|t2(18|50)|t6(00|10|18)|ta(gt|lk)|tcl\-|tdg\-|tel(i|m)|tim\-|t\-mo|to(pl|sh)|ts(70|m\-|m3|m5)|tx\-9|up(\.b|g1|si)|utst|v400|v750|veri|vi(rg|te)|vk(40|5[0-3]|\-v)|vm40|voda|vulc|vx(52|53|60|61|70|80|81|83|85|98)|w3c(\-| )|webc|whit|wi(g |nc|nw)|wmlb|wonu|x700|yas\-|your|zeto|zte\-/i',substr($useragent,0,4))) {
     print "    <link rel=\"stylesheet\" type=\"text/css\" media=\"screen and (min-device-width: 380px)\" href=\"css/pistar-css.php?version=0.95\" />\n";
     print "    <link rel=\"stylesheet\" type=\"text/css\" media=\"screen and (max-device-width: 379px)\" href=\"css/pistar-css-mini.php?version=0.95\" />\n";
+    print "    <link rel=\"stylesheet\" type=\"text/css\" media=\"(prefers-color-scheme: dark)\" href=\"css/pistar-dark.css?version=0.95\" />\n";
   } else {
     print "    <link rel=\"stylesheet\" type=\"text/css\" media=\"screen and (min-width: 830px)\" href=\"css/pistar-css.php?version=0.95\" />\n";
     print "    <link rel=\"stylesheet\" type=\"text/css\" media=\"screen and (max-width: 829px)\" href=\"css/pistar-css-mini.php?version=0.95\" />\n";
+    print "    <link rel=\"stylesheet\" type=\"text/css\" media=\"(prefers-color-scheme: dark)\" href=\"css/pistar-dark.css?version=0.95\" />\n";
   }
 }
 ?>

--- a/config/browserdetect.php
+++ b/config/browserdetect.php
@@ -2,17 +2,17 @@
 if(empty($_SERVER['HTTP_USER_AGENT'])) {
   print "    <link rel=\"stylesheet\" type=\"text/css\" media=\"screen and (min-width: 830px)\" href=\"css/pistar-css.php?version=0.95\" />\n";
   print "    <link rel=\"stylesheet\" type=\"text/css\" media=\"screen and (max-width: 829px)\" href=\"css/pistar-css-mini.php?version=0.95\" />\n";
-  print "    <link rel=\"stylesheet\" type=\"text/css\" media=\"(prefers-color-scheme: dark)\" href=\"css/pistar-dark.css?version=0.95\" />\n";
+  print "    <link rel=\"stylesheet\" type=\"text/css\" href=\"css/pistar-dark.css?version=0.95\" />\n";
 } else {
   $useragent=$_SERVER['HTTP_USER_AGENT'];
   if (preg_match('/(android|bb\d+|meego).+mobile|avantgo|bada\/|blackberry|blazer|compal|elaine|fennec|hiptop|iemobile|ip(hone|od)|iris|kindle|lge |maemo|midp|mmp|mobile.+firefox|netfront|opera m(ob|in)i|palm( os)?|phone|p(ixi|re)\/|plucker|pocket|psp|series(4|6)0|symbian|treo|up\.(browser|link)|vodafone|wap|windows ce|xda|xiino/i',$useragent)||preg_match('/1207|6310|6590|3gso|4thp|50[1-6]i|770s|802s|a wa|abac|ac(er|oo|s\-)|ai(ko|rn)|al(av|ca|co)|amoi|an(ex|ny|yw)|aptu|ar(ch|go)|as(te|us)|attw|au(di|\-m|r |s )|avan|be(ck|ll|nq)|bi(lb|rd)|bl(ac|az)|br(e|v)w|bumb|bw\-(n|u)|c55\/|capi|ccwa|cdm\-|cell|chtm|cldc|cmd\-|co(mp|nd)|craw|da(it|ll|ng)|dbte|dc\-s|devi|dica|dmob|do(c|p)o|ds(12|\-d)|el(49|ai)|em(l2|ul)|er(ic|k0)|esl8|ez([4-7]0|os|wa|ze)|fetc|fly(\-|_)|g1 u|g560|gene|gf\-5|g\-mo|go(\.w|od)|gr(ad|un)|haie|hcit|hd\-(m|p|t)|hei\-|hi(pt|ta)|hp( i|ip)|hs\-c|ht(c(\-| |_|a|g|p|s|t)|tp)|hu(aw|tc)|i\-(20|go|ma)|i230|iac( |\-|\/)|ibro|idea|ig01|ikom|im1k|inno|ipaq|iris|ja(t|v)a|jbro|jemu|jigs|kddi|keji|kgt( |\/)|klon|kpt |kwc\-|kyo(c|k)|le(no|xi)|lg( g|\/(k|l|u)|50|54|\-[a-w])|libw|lynx|m1\-w|m3ga|m50\/|ma(te|ui|xo)|mc(01|21|ca)|m\-cr|me(rc|ri)|mi(o8|oa|ts)|mmef|mo(01|02|bi|de|do|t(\-| |o|v)|zz)|mt(50|p1|v )|mwbp|mywa|n10[0-2]|n20[2-3]|n30(0|2)|n50(0|2|5)|n7(0(0|1)|10)|ne((c|m)\-|on|tf|wf|wg|wt)|nok(6|i)|nzph|o2im|op(ti|wv)|oran|owg1|p800|pan(a|d|t)|pdxg|pg(13|\-([1-8]|c))|phil|pire|pl(ay|uc)|pn\-2|po(ck|rt|se)|prox|psio|pt\-g|qa\-a|qc(07|12|21|32|60|\-[2-7]|i\-)|qtek|r380|r600|raks|rim9|ro(ve|zo)|s55\/|sa(ge|ma|mm|ms|ny|va)|sc(01|h\-|oo|p\-)|sdk\/|se(c(\-|0|1)|47|mc|nd|ri)|sgh\-|shar|sie(\-|m)|sk\-0|sl(45|id)|sm(al|ar|b3|it|t5)|so(ft|ny)|sp(01|h\-|v\-|v )|sy(01|mb)|t2(18|50)|t6(00|10|18)|ta(gt|lk)|tcl\-|tdg\-|tel(i|m)|tim\-|t\-mo|to(pl|sh)|ts(70|m\-|m3|m5)|tx\-9|up(\.b|g1|si)|utst|v400|v750|veri|vi(rg|te)|vk(40|5[0-3]|\-v)|vm40|voda|vulc|vx(52|53|60|61|70|80|81|83|85|98)|w3c(\-| )|webc|whit|wi(g |nc|nw)|wmlb|wonu|x700|yas\-|your|zeto|zte\-/i',substr($useragent,0,4))) {
     print "    <link rel=\"stylesheet\" type=\"text/css\" media=\"screen and (min-device-width: 380px)\" href=\"css/pistar-css.php?version=0.95\" />\n";
     print "    <link rel=\"stylesheet\" type=\"text/css\" media=\"screen and (max-device-width: 379px)\" href=\"css/pistar-css-mini.php?version=0.95\" />\n";
-    print "    <link rel=\"stylesheet\" type=\"text/css\" media=\"(prefers-color-scheme: dark)\" href=\"css/pistar-dark.css?version=0.95\" />\n";
+    print "    <link rel=\"stylesheet\" type=\"text/css\" href=\"css/pistar-dark.css?version=0.95\" />\n";
   } else {
     print "    <link rel=\"stylesheet\" type=\"text/css\" media=\"screen and (min-width: 830px)\" href=\"css/pistar-css.php?version=0.95\" />\n";
     print "    <link rel=\"stylesheet\" type=\"text/css\" media=\"screen and (max-width: 829px)\" href=\"css/pistar-css-mini.php?version=0.95\" />\n";
-    print "    <link rel=\"stylesheet\" type=\"text/css\" media=\"(prefers-color-scheme: dark)\" href=\"css/pistar-dark.css?version=0.95\" />\n";
+    print "    <link rel=\"stylesheet\" type=\"text/css\" href=\"css/pistar-dark.css?version=0.95\" />\n";
   }
 }
 ?>

--- a/css/pistar-dark.css
+++ b/css/pistar-dark.css
@@ -72,6 +72,10 @@
 	.nice-select, .nice-select-dropdown {
 		background-color: #c8c8c8 !important;
 	}
+	textarea {
+		background-color: #212121;
+		color: #fff;
+	}
 
 	/* Toggle switches */
 	input.toggle-round-flat + label {

--- a/css/pistar-dark.css
+++ b/css/pistar-dark.css
@@ -1,0 +1,93 @@
+@media (prefers-color-scheme: dark) {
+	body {
+		background-color: #120f0a !important;
+	}
+
+	/* A less-intense version of red. */
+	.header,
+	.footer,
+	table th,
+	input.toggle-round-flat:checked + label,
+	input.toggle-round-flat:checked + label:after {
+		background-color: #bb2917 !important;
+	}
+
+	/* Various containers */
+	.content, .contentwide {
+		color: #fff;
+	}
+	.content, .contentwide, .container {
+		background: #000;
+	}
+
+	/* Tables */
+	table {
+		background: #000 !important;
+		border-color: #fff;
+		color: #fff;
+	}
+	table tr:nth-child(odd) {
+		background: #888;
+		color: #fff;
+	}
+	table tr:nth-child(even) {
+		background: #555;
+		color: #fff;
+	}
+	table th, table td {
+		color: #fff;
+	}
+	table td a {
+		color: #fff !important;
+	}
+	td[style="background:#f33;"] {
+		/* Black text on high-loss signals -- no CSS class to target */
+		color: #000;
+	}
+	.nav td[style="background: #ffffff;"] {
+		/* The tables in the left-hand column are explicitly turned white.
+			Let's correct that. */
+		background-color: #555 !important;
+	}
+	td[style*="color:#030;"] {
+		/* Enabled modes and networks. */
+		color: #cfc !important;
+	}
+	td[style*="background: #b55"] {
+		/* Inactive services */
+		background: #800 !important;
+	}
+	td[style*="background: #1b1"] {
+		/* Inactive services */
+		background: #0a0 !important;
+	}
+
+	/* Inputs and form fields */
+	.current, li.option {
+		color: #000;
+	}
+	input, select {
+		background-color: #c8c8c8;
+	}
+	.nice-select, .nice-select-dropdown {
+		background-color: #c8c8c8 !important;
+	}
+
+	/* Toggle switches */
+	input.toggle-round-flat + label {
+		/* Toggle switch border */
+		background-color: #8a8a8a;
+	}
+	tr:nth-child(odd) input.toggle-round-flat + label {
+		/* Make them stand out more on odd-colored rows. */
+		background: #bbb;
+	}
+	input.toggle-round-flat + label:before {
+		/* Toggle switch background */
+		background-color: #343434;
+	}
+	input.toggle-round-flat + label:after {
+		/* Inactive toggle switch color */
+		background-color: #8a8a8a;
+	}
+}


### PR DESCRIPTION
The default Pi-Star color scheme is extremely bright, especially when using it at night.  This pull request adds a dark theme using the `(prefers-color-scheme)` CSS media query, which [is supported by almost all web browsers](https://caniuse.com/?search=prefers-color-scheme).  Thus, if the browser requests a darker color scheme, Pi-Star will adapt.

![DarkMode](https://user-images.githubusercontent.com/19931245/201274512-71d8fba9-2c49-4617-8cec-7fc531ac3536.png)

Note that this pull request does not respect any custom CSS that the user may have specified, nor can it be customized by the end user.